### PR TITLE
[CDF-3676] Add FunctionsAPI.create()

### DIFF
--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -23,7 +23,7 @@ class FunctionsAPI(APIClient):
 
         Args:
             name (str):                 Name of function
-            folder (str):               Path to folder (relative to current working directory) where the function source code is located
+            folder (str):               Path to folder where the function source code is located
             external_id (str):          External id of the function
             description (str):          Description of the function
             owner (str):                Owner of the function
@@ -76,7 +76,7 @@ class FunctionsAPI(APIClient):
                     zf.write(os.path.join(root, filename))
             zf.close()
 
-            file = self._cognite_client.files.upload(zip_path, name=name)
+            file = self._cognite_client.files.upload(zip_path, name=f"{name}.zip")
 
         os.chdir(current_dir)
 

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -1,10 +1,58 @@
+import os
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
+from zipfile import ZipFile
 
 from cognite.client._api_client import APIClient
-from cognite.experimental.data_classes import FunctionList
+from cognite.experimental.data_classes import Function, FunctionList
 
 
 class FunctionsAPI(APIClient):
+    def create(
+        self,
+        name: str,
+        folder: str = None,
+        file_id: int = None,
+        external_id: str = None,
+        description: str = "",
+        owner: str = "",
+        api_key: str = None,
+        secrets: Dict = None,
+    ) -> Function:
+        """Creates a new function from source code located in folder
+
+        Args:
+            name (str):                 Name of function
+            folder (str):               Path to folder (relative to current working directory) where the function source code is located
+            external_id (str):          External id of the function
+            description (str):          Description of the function
+            owner (str):                Owner of the function
+            api_key (str):              Api key to be used by the CogniteClient in the function source code
+            secrets (Dict[str, str]):   Secrets attached to the function ((key, value) pairs)
+
+        Returns:
+            Function: The created function.
+        """
+        if folder and file_id:
+            raise TypeError("Exactly one of the arguments `path` and `file_id` is required, but both were given.")
+        if not folder and not file_id:
+            raise TypeError("Exactly one of the arguments `path` and `file_id` is required, but none were given.")
+
+        if not file_id:
+            file_id = self._zip_and_upload_folder(folder, name)
+
+        url = "/functions"
+        function = {"name": name, "description": description, "owner": owner, "fileId": file_id}
+        if external_id:
+            function.update({"externalId": external_id})
+        if api_key:
+            function.update({"apiKey": api_key})
+        if secrets:
+            function.update({"secrets": secrets})
+        body = {"items": [function]}
+        res = self._post(url, json=body)
+        return Function._load(res.json()["items"][0])
+
     def list(self) -> FunctionList:
         """List all functions.
 
@@ -14,3 +62,22 @@ class FunctionsAPI(APIClient):
         url = "/functions"
         res = self._get(url)
         return FunctionList._load(res.json()["items"])
+
+    def _zip_and_upload_folder(self, folder, name) -> int:
+        current_dir = os.getcwd()
+        os.chdir(folder)
+
+        with TemporaryDirectory() as tmpdir:
+            zip_path = os.path.join(tmpdir, "function.zip")
+            zf = ZipFile(zip_path, "w")
+            for root, dirs, files in os.walk("."):
+                zf.write(root)
+                for filename in files:
+                    zf.write(os.path.join(root, filename))
+            zf.close()
+
+            file = self._cognite_client.files.upload(zip_path, name=name)
+
+        os.chdir(current_dir)
+
+        return file.id

--- a/tests/tests_unit/test_api/function_code/handler.py
+++ b/tests/tests_unit/test_api/function_code/handler.py
@@ -1,0 +1,2 @@
+def handle(data):
+    return {"assetId": 1234}

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -1,39 +1,82 @@
+import os
+
 import pytest
 
 from cognite.experimental import CogniteClient
-from cognite.experimental.data_classes import FunctionList
+from cognite.experimental.data_classes import Function, FunctionList
 
 COGNITE_CLIENT = CogniteClient()
 FUNCTIONS_API = COGNITE_CLIENT.functions
+FILES_API = COGNITE_CLIENT.files
+
+
+EXAMPLE_FUNCTION = {
+    "id": 1233456,
+    "name": "myfunction",
+    "externalId": "func-no-123",
+    "description": "my fabulous function",
+    "owner": "ola.normann@cognite.com",
+    "status": "Ready",
+    "fileId": 1234,
+    "createdTime": 1585662507939,
+    "apiKey": "***",
+    "secrets": {"key1": "***", "key2": "***"},
+}
 
 
 @pytest.fixture
-def mock_functions_response(rsps):
-    response_body = {
-        "items": [
-            {
-                "id": 1233456,
-                "name": "myfunction",
-                "externalId": "func-no-123",
-                "description": "my fabulous function",
-                "owner": "ola.normann@cognite.com",
-                "status": "Ready",
-                "fileId": 1234,
-                "createdTime": 1585662507939,
-                "apiKey": "***",
-                "secrets": {"key1": "***", "key2": "***"},
-            }
-        ]
-    }
+def mock_functions_list_response(rsps):
+    response_body = {"items": [EXAMPLE_FUNCTION]}
 
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions"
     rsps.add(rsps.GET, url, status=200, json=response_body)
+
+    yield rsps
+
+
+@pytest.fixture
+def mock_functions_create_response(rsps):
+    files_response_body = {
+        "name": "myfunction",
+        "id": 1234,
+        "uploaded": True,
+        "createdTime": 1585662507939,
+        "lastUpdatedTime": 1585662507939,
+        "uploadUrl": "https://upload.here",
+    }
+
+    rsps.assert_all_requests_are_fired = False
+
+    files_url = FILES_API._get_base_url_with_base_path() + "/files"
+    rsps.add(rsps.POST, files_url, status=201, json=files_response_body)
+    rsps.add(rsps.PUT, "https://upload.here", status=200)
+
+    functions_url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions"
+    rsps.add(rsps.POST, functions_url, status=201, json={"items": [EXAMPLE_FUNCTION]})
+
     yield rsps
 
 
 class TestFunctionsAPI:
-    def test_list(self, mock_functions_response):
+    def test_create_with_path(self, mock_functions_create_response):
+        folder = os.path.join(os.path.dirname(__file__), "function_code")
+        res = FUNCTIONS_API.create(name="myfunction", folder=folder)
+
+        assert isinstance(res, Function)
+        assert mock_functions_create_response.calls[2].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_create_with_file_id(self, mock_functions_create_response):
+        res = FUNCTIONS_API.create(name="myfunction", file_id=1234)
+
+        assert isinstance(res, Function)
+        assert mock_functions_create_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_create_with_path_and_file_id_raises(self, mock_functions_create_response):
+        with pytest.raises(TypeError):
+            FUNCTIONS_API.create(name="myfunction", folder="some/folder", file_id=1234)
+
+    def test_list(self, mock_functions_list_response):
         res = FUNCTIONS_API.list()
 
         assert isinstance(res, FunctionList)
-        assert mock_functions_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_functions_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)


### PR DESCRIPTION
This PR adds method `FunctionsAPI.create()` which can be used to create a function in two ways:
1) By using the `folder` argument which is the relative path to the folder containing the function source code (i.e. handler.py):
```
from cognite.experimental import CogniteClient
client = CogniteClient()

func = client.functions.create(name="myfunction", path="path/to/code")
```

2) By using the `file_id` argument if the source code is already uploaded to the files-API:
```
func = client.functions.create(name="myfunction", file_id=1234)
```
Arguments `name` and exactly one of `folder` or `file_id` are required. Optional arguments are: `external_id`, `description`, `owner`, `api_key`, `secrets`.

The method `client.functions.create()` returns an object of type `Function`:
```
{
    "id": 7344064945410280,
    "name": "henkistest",
    "description": "",
    "owner": "",
    "status": "Queued",
    "file_id": 8560551814397155,
    "created_time": "2020-04-02 22:06:18",
    "secrets": {}
}
```