### PR TITLE
[CDF-3677] Add FunctionsAPI.delete()

### DIFF
--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -70,7 +70,7 @@ class FunctionsAPI(APIClient):
         return Function._load(res.json()["items"][0])
 
     def delete(self, id: Union[int, List[int]] = None, external_id: Union[str, List[str]] = None) -> None:
-        """Delete one or more functions.s
+        """Delete one or more functions.
 
         Args:
             id (Union[int, List[int]): Id or list of ids

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -1,6 +1,6 @@
 import os
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from zipfile import ZipFile
 
 from cognite.client._api_client import APIClient
@@ -8,6 +8,8 @@ from cognite.experimental.data_classes import Function, FunctionList
 
 
 class FunctionsAPI(APIClient):
+    _RESOURCE_PATH = "/functions"
+
     def create(
         self,
         name: str,
@@ -32,6 +34,20 @@ class FunctionsAPI(APIClient):
 
         Returns:
             Function: The created function.
+
+        Examples:
+
+            Create function with source code in folder::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> function = c.functions.create(name="myfunction", folder="path/to/code")
+
+            Create function with file_id from already uploaded source code::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> function = c.functions.create(name="myfunction", file_id=123)
         """
         if folder and file_id:
             raise TypeError("Exactly one of the arguments `path` and `file_id` is required, but both were given.")
@@ -53,11 +69,39 @@ class FunctionsAPI(APIClient):
         res = self._post(url, json=body)
         return Function._load(res.json()["items"][0])
 
+    def delete(self, id: Union[int, List[int]] = None, external_id: Union[str, List[str]] = None) -> None:
+        """Delete one or more functions.s
+
+        Args:
+            id (Union[int, List[int]): Id or list of ids
+            external_id (Union[str, List[str]]): External ID or list of external ids
+
+        Returns:
+            None
+
+        Example:
+
+            Delete functions by id or external id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> c.functions.delete(id=[1,2,3], external_id="function3")
+        """
+        self._delete_multiple(ids=id, external_ids=external_id, wrap_ids=True)
+
     def list(self) -> FunctionList:
         """List all functions.
 
         Returns:
             FunctionList: List of functions
+        
+        Example:
+
+            List functions::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> functions_list = c.functions.list()
         """
         url = "/functions"
         res = self._get(url)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -4,6 +4,7 @@ import pytest
 
 from cognite.experimental import CogniteClient
 from cognite.experimental.data_classes import Function, FunctionList
+from tests.utils import jsgz_load
 
 COGNITE_CLIENT = CogniteClient()
 FUNCTIONS_API = COGNITE_CLIENT.functions
@@ -57,6 +58,14 @@ def mock_functions_create_response(rsps):
     yield rsps
 
 
+@pytest.fixture
+def mock_functions_delete_response(rsps):
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/delete"
+    rsps.add(rsps.POST, url, status=200, json={})
+
+    yield rsps
+
+
 class TestFunctionsAPI:
     def test_create_with_path(self, mock_functions_create_response):
         folder = os.path.join(os.path.dirname(__file__), "function_code")
@@ -74,6 +83,20 @@ class TestFunctionsAPI:
     def test_create_with_path_and_file_id_raises(self, mock_functions_create_response):
         with pytest.raises(TypeError):
             FUNCTIONS_API.create(name="myfunction", folder="some/folder", file_id=1234)
+
+    def test_delete_single_id(self, mock_functions_delete_response):
+        res = FUNCTIONS_API.delete(id=1)
+        assert {"items": [{"id": 1}]} == jsgz_load(mock_functions_delete_response.calls[0].request.body)
+
+    def test_delete_single_external_id(self, mock_functions_delete_response):
+        res = FUNCTIONS_API.delete(external_id="func1")
+        assert {"items": [{"externalId": "func1"}]} == jsgz_load(mock_functions_delete_response.calls[0].request.body)
+
+    def test_delete_multiple_id_and_multiple_external_id(self, mock_functions_delete_response):
+        res = FUNCTIONS_API.delete(id=[1, 2, 3], external_id=["func1", "func2"])
+        assert {
+            "items": [{"id": 1}, {"id": 2}, {"id": 3}, {"externalId": "func1"}, {"externalId": "func2"}]
+        } == jsgz_load(mock_functions_delete_response.calls[0].request.body)
 
     def test_list(self, mock_functions_list_response):
         res = FUNCTIONS_API.list()


### PR DESCRIPTION
This PR adds `FunctionsAPI.delete()`. Accepted arguments are `id: Union[int, List[int]]` and `external_id: Union[str, List[str]]`, and the method is used as:
```
from cognite.experimental import CogniteClient
c = CogniteClient()
c.functions.delete(id=[1,2,3], external_id="function3")
```