### PR TITLE
[CDF-3675] Add FunctionsAPI.retrieve() and FunctionsAPI.retrieve_multiple()

### DIFF
--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -1,14 +1,16 @@
 import os
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 from zipfile import ZipFile
 
+from cognite.client import utils
 from cognite.client._api_client import APIClient
 from cognite.experimental.data_classes import Function, FunctionList
 
 
 class FunctionsAPI(APIClient):
     _RESOURCE_PATH = "/functions"
+    _LIST_CLASS = FunctionList
 
     def create(
         self,
@@ -106,6 +108,66 @@ class FunctionsAPI(APIClient):
         url = "/functions"
         res = self._get(url)
         return FunctionList._load(res.json()["items"])
+
+    def retrieve(self, id: Optional[int] = None, external_id: Optional[str] = None) -> Optional[Function]:
+        """Retrieve a single function by id.
+
+        Args:
+            id (int, optional): ID
+            external_id (str, optional): External ID
+
+        Returns:
+            Optional[Function]: Requested function or None if it does not exist.
+
+        Examples:
+
+            Get function by id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.functions.retrieve(id=1)
+
+            Get function by external id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.functions.retrieve(external_id="1")
+        """
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
+        return self._retrieve_multiple(ids=id, external_ids=external_id, wrap_ids=True)
+
+    def retrieve_multiple(
+        self,
+        ids: Optional[List[int]] = None,
+        external_ids: Optional[List[str]] = None,
+        ignore_unknown_ids: bool = False,
+    ) -> FunctionList:
+        """Retrieve multiple functions by id.
+
+        Args:
+            ids (List[int], optional): IDs
+            external_ids (List[str], optional): External IDs
+
+        Returns:
+            FunctionList: The requested functions.
+
+        Examples:
+
+            Get function by id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.functions.retrieve_multiple(ids=[1, 2, 3])
+
+            Get functions by external id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.functions.retrieve_multiple(external_ids=["func1", "func2"])
+        """
+        utils._auxiliary.assert_type(ids, "id", [List], allow_none=True)
+        utils._auxiliary.assert_type(external_ids, "external_id", [List], allow_none=True)
+        return self._retrieve_multiple(ids=ids, external_ids=external_ids, wrap_ids=True)
 
     def _zip_and_upload_folder(self, folder, name) -> int:
         current_dir = os.getcwd()

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -137,10 +137,7 @@ class FunctionsAPI(APIClient):
         return self._retrieve_multiple(ids=id, external_ids=external_id, wrap_ids=True)
 
     def retrieve_multiple(
-        self,
-        ids: Optional[List[int]] = None,
-        external_ids: Optional[List[str]] = None,
-        ignore_unknown_ids: bool = False,
+        self, ids: Optional[List[int]] = None, external_ids: Optional[List[str]] = None
     ) -> FunctionList:
         """Retrieve multiple functions by id.
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -36,6 +36,16 @@ def mock_functions_list_response(rsps):
 
 
 @pytest.fixture
+def mock_functions_retrieve_response(rsps):
+    response_body = {"items": [EXAMPLE_FUNCTION]}
+
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/byids"
+    rsps.add(rsps.POST, url, status=200, json=response_body)
+
+    yield rsps
+
+
+@pytest.fixture
 def mock_functions_create_response(rsps):
     files_response_body = {
         "name": "myfunction",
@@ -103,3 +113,32 @@ class TestFunctionsAPI:
 
         assert isinstance(res, FunctionList)
         assert mock_functions_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_retrieve_by_id(self, mock_functions_retrieve_response):
+        res = FUNCTIONS_API.retrieve(id=1)
+        assert isinstance(res, Function)
+        assert mock_functions_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_retrieve_by_external_id(self, mock_functions_retrieve_response):
+        res = FUNCTIONS_API.retrieve(external_id="func1")
+        assert isinstance(res, Function)
+        assert mock_functions_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_retrieve_by_id_and_external_id_raises(self):
+        with pytest.raises(AssertionError):
+            FUNCTIONS_API.retrieve(id=1, external_id="func1")
+
+    def test_retrieve_multiple_by_ids(self, mock_functions_retrieve_response):
+        res = FUNCTIONS_API.retrieve_multiple(ids=[1])
+        assert isinstance(res, FunctionList)
+        assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_retrieve_multiple_by_external_ids(self, mock_functions_retrieve_response):
+        res = FUNCTIONS_API.retrieve_multiple(external_ids=["func1"])
+        assert isinstance(res, FunctionList)
+        assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_retrieve_multiple_by_ids_and_external_ids(self, mock_functions_retrieve_response):
+        res = FUNCTIONS_API.retrieve_multiple(ids=[1], external_ids=["func1"])
+        assert isinstance(res, FunctionList)
+        assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)


### PR DESCRIPTION
This PR adds methods `FunctionsAPI.retrieve()` and `FunctionsAPI.retrieve_multiple()`.

The first of these can retrieve a single function by either `id` or `external_id` (mutually exclusive):
```
from cognite.experimental import CogniteClient
c = CogniteClient()
func = c.functions.retrieve(id=1)
```
or
```
func = c.functions.retrieve(external_id="somefunc")
```

The second can retrieve multiple functions specified by keyword arguments `ids (list)` and/or `external_ids (list)`:
```
funcs = c.functions.retrieve_multiple(ids=[1, 2, 3], external_ids=["somefunc"])
```