### PR TITLE
[CDF-3678] [CDF-3680] Add FunctionsAPI.call()

### DIFF
--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -166,7 +166,11 @@ class FunctionsAPI(APIClient):
         utils._auxiliary.assert_type(external_ids, "external_id", [List], allow_none=True)
         return self._retrieve_multiple(ids=ids, external_ids=external_ids, wrap_ids=True)
 
-    def call(self, id: int, data=None, asyncronous: bool = False) -> FunctionCall:
+    def call(self, id: int = None, external_id: str = None, data=None, asyncronous: bool = False) -> FunctionCall:
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
+        if external_id:
+            id = self.retrieve(external_id=external_id).id
+
         url = f"/functions/{id}/call" if not asyncronous else f"/functions/{id}/async_call"
         body = {}
         if data:

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -69,7 +69,7 @@ class FunctionsAPI(APIClient):
             function.update({"secrets": secrets})
         body = {"items": [function]}
         res = self._post(url, json=body)
-        return Function._load(res.json()["items"][0])
+        return Function._load(res.json()["items"][0], cognite_client=self._cognite_client)
 
     def delete(self, id: Union[int, List[int]] = None, external_id: Union[str, List[str]] = None) -> None:
         """Delete one or more functions.
@@ -107,7 +107,7 @@ class FunctionsAPI(APIClient):
         """
         url = "/functions"
         res = self._get(url)
-        return FunctionList._load(res.json()["items"])
+        return FunctionList._load(res.json()["items"], cognite_client=self._cognite_client)
 
     def retrieve(self, id: Optional[int] = None, external_id: Optional[str] = None) -> Optional[Function]:
         """Retrieve a single function by id.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -166,12 +166,38 @@ class FunctionsAPI(APIClient):
         utils._auxiliary.assert_type(external_ids, "external_id", [List], allow_none=True)
         return self._retrieve_multiple(ids=ids, external_ids=external_ids, wrap_ids=True)
 
-    def call(self, id: int = None, external_id: str = None, data=None, asyncronous: bool = False) -> FunctionCall:
+    def call(self, id: int = None, external_id: str = None, data=None, asynchronous: bool = False) -> FunctionCall:
+        """Call a function by its ID or external ID.
+
+        Args:
+            id (int, optional): ID
+            external_id (str, optional): External ID
+            data (optional): Input data to the function (JSON serializable). This data is passed deserialized into the function through one of the arguments called data.
+            asynchronous (bool): Call the function asynchronously. Defaults to false.
+
+        Returns:
+            FunctionCall: A function call object.
+
+        Examples:
+
+            Call a function by id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> call = c.functions.call(id=1)
+
+            Call a function directly on the `Function` object::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> func = c.functions.retrieve(id=1)
+                >>> call = func.call()
+        """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
         if external_id:
             id = self.retrieve(external_id=external_id).id
 
-        url = f"/functions/{id}/call" if not asyncronous else f"/functions/{id}/async_call"
+        url = f"/functions/{id}/call" if not asynchronous else f"/functions/{id}/async_call"
         body = {}
         if data:
             body = {"data": data}

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -5,7 +5,7 @@ from zipfile import ZipFile
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient
-from cognite.experimental.data_classes import Function, FunctionList
+from cognite.experimental.data_classes import Function, FunctionCall, FunctionList
 
 
 class FunctionsAPI(APIClient):
@@ -165,6 +165,14 @@ class FunctionsAPI(APIClient):
         utils._auxiliary.assert_type(ids, "id", [List], allow_none=True)
         utils._auxiliary.assert_type(external_ids, "external_id", [List], allow_none=True)
         return self._retrieve_multiple(ids=ids, external_ids=external_ids, wrap_ids=True)
+
+    def call(self, id: int, data=None, asyncronous: bool = False) -> FunctionCall:
+        url = f"/functions/{id}/call" if not asyncronous else f"/functions/{id}/async_call"
+        body = {}
+        if data:
+            body = {"data": data}
+        res = self._post(url, json=body)
+        return FunctionCall._load(res.json())
 
     def _zip_and_upload_folder(self, folder, name) -> int:
         current_dir = os.getcwd()

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -46,8 +46,8 @@ class Function(CogniteResource):
         self.secrets = secrets
         self._cognite_client = cognite_client
 
-    def call(self, data=None, asyncronous: bool = False):
-        return self._cognite_client.functions.call(self.id, data, asyncronous)
+    def call(self, data=None, asynchronous: bool = False):
+        return self._cognite_client.functions.call(self.id, data, asynchronous)
 
 
 class FunctionList(CogniteResourceList):

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -46,7 +46,42 @@ class Function(CogniteResource):
         self.secrets = secrets
         self._cognite_client = cognite_client
 
+    def call(self, data=None, asyncronous: bool = False):
+        return self._cognite_client.functions.call(self.id, data, asyncronous)
+
 
 class FunctionList(CogniteResourceList):
     _RESOURCE = Function
     _ASSERT_CLASSES = False
+
+
+class FunctionCall(CogniteResource):
+    """A representation of a Cognite Function call.
+
+    Args:
+        id (int): Id of the function call.
+        start_time (int): Start time in UNIX.
+        end_time (int): End time in UNIX.
+        response (str): Response returned by the function.
+        status (str): Status of the function call ("Running" or "Completed").
+        error (dict): Error from the function call. It contains an error message and the stack trace.
+        cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
+    """
+
+    def __init__(
+        self,
+        id: int = None,
+        start_time: int = None,
+        end_time: int = None,
+        response: str = None,
+        status: str = None,
+        error: dict = None,
+        cognite_client=None,
+    ):
+        self.id = id
+        self.start_time = start_time
+        self.end_time = end_time
+        self.response = response
+        self.status = status
+        self.error = error
+        self._cognite_client = cognite_client

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -59,10 +59,10 @@ class FunctionCall(CogniteResource):
     """A representation of a Cognite Function call.
 
     Args:
-        id (int): Id of the function call.
-        start_time (int): Start time in UNIX.
-        end_time (int): End time in UNIX.
-        response (str): Response returned by the function.
+        id (int): A server-generated ID for the object.
+        start_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        end_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        response (str): Response from the function. The function must return a JSON serializable object.
         status (str): Status of the function call ("Running" or "Completed").
         error (dict): Error from the function call. It contains an error message and the stack trace.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -47,7 +47,7 @@ class Function(CogniteResource):
         self._cognite_client = cognite_client
 
     def call(self, data=None, asynchronous: bool = False):
-        return self._cognite_client.functions.call(self.id, data, asynchronous)
+        return self._cognite_client.functions.call(id=self.id, data=data, asynchronous=asynchronous)
 
 
 class FunctionList(CogniteResourceList):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -77,10 +77,11 @@ def mock_functions_delete_response(rsps):
 
 
 @pytest.fixture
-def mock_functions_call_response(rsps):
+def mock_functions_call_completed_response(rsps):
     response_body_sync = {
         "id": 7255309231137124,
         "startTime": 1585925306822,
+        "endTime": 1585925310822,
         "response": "Hello World!",
         "status": "Completed",
     }
@@ -90,8 +91,34 @@ def mock_functions_call_response(rsps):
     url_sync = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
     url_async = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/async_call"
     rsps.assert_all_requests_are_fired = False
-    rsps.add(rsps.POST, url_sync, status=200, json=response_body_sync)
-    rsps.add(rsps.POST, url_async, status=200, json=response_body_async)
+    rsps.add(rsps.POST, url_sync, status=201, json=response_body_sync)
+    rsps.add(rsps.POST, url_async, status=201, json=response_body_async)
+
+    yield rsps
+
+
+@pytest.fixture
+def mock_functions_call_failed_response(rsps):
+    response_body = {
+        "id": 7255309231137124,
+        "startTime": 1585925306822,
+        "endTime": 1585925310822,
+        "status": "Failed",
+        "error": {"message": "some message", "trace": "some stack trace"},
+    }
+
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
+    rsps.add(rsps.POST, url, status=201, json=response_body)
+
+    yield rsps
+
+
+@pytest.fixture
+def mock_functions_call_timeout_response(rsps):
+    response_body = {"id": 7255309231137124, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Timeout"}
+
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
+    rsps.add(rsps.POST, url, status=201, json=response_body)
 
     yield rsps
 
@@ -163,12 +190,22 @@ class TestFunctionsAPI:
         assert isinstance(res, FunctionList)
         assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
-    def test_function_call(self, mock_functions_call_response):
+    def test_function_call(self, mock_functions_call_completed_response):
         res = FUNCTIONS_API.call(id=1234)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
 
-    def test_function_call_async(self, mock_functions_call_response):
+    def test_function_call_async(self, mock_functions_call_completed_response):
         res = FUNCTIONS_API.call(id=1234, asyncronous=True)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
+
+    def test_function_call_failed(self, mock_functions_call_failed_response):
+        res = FUNCTIONS_API.call(id=1234)
+        assert isinstance(res, FunctionCall)
+        assert mock_functions_call_failed_response.calls[0].response.json() == res.dump(camel_case=True)
+
+    def test_function_call_timout(self, mock_functions_call_timeout_response):
+        res = FUNCTIONS_API.call(id=1234)
+        assert isinstance(res, FunctionCall)
+        assert mock_functions_call_timeout_response.calls[0].response.json() == res.dump(camel_case=True)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -213,7 +213,7 @@ class TestFunctionsAPI:
         assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_function_async_call(self, mock_functions_call_completed_response):
-        res = FUNCTIONS_API.call(id=1234, asyncronous=True)
+        res = FUNCTIONS_API.call(id=1234, asynchronous=True)
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
 


### PR DESCRIPTION
This PR adds `FunctionsAPI.call()`, which is used to call functions by `id` or `external_id`. It is used as follows:
```
from cognite.experimental import CogniteClient
c = CogniteClient()
call = c.functions.call(id=4172094376815850)
```
Where a `Completed` call looks like:
```
print(call)
{
    "id": 4172094376815850,
    "start_time": "2020-04-06 07:52:03",
    "end_time": "2020-04-06 07:52:04",
    "response": {
        "assetId": 1234
    },
    "status": "Completed"
}
```
Alternatively, you can make the function call from a `Function` object directly:
```
func = c.functions.retrieve(id=4172094376815850)
call = func.call()
```

Optional arguments are `data`, which needs to be JSON serializable, and `asynchronous` (defaults to `False`) which lets you call the function asynchronously.