### PR TITLE
[CDF-3767] Add FunctionCallsAPI.list() and FunctionCallsAPI.retrieve()

### DIFF
--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -233,8 +233,8 @@ class FunctionCallsAPI(APIClient):
         """List all calls associated with a specific function.
 
         Args:
-            function_id (int, optional): ID of the function associated with the call.
-            external_id (str, optional): External ID of the function associated with the call.
+            function_id (int, optional): ID of the function on which the calls are made.
+            external_id (str, optional): External ID of the function on which the calls are made.
 
         Returns:
             FunctionCallList: List of function calls
@@ -269,8 +269,8 @@ class FunctionCallsAPI(APIClient):
 
         Args:
             call_id (int): ID of the call.
-            function_id (int, optional): ID of the function associated with the call.
-            external_id (str, optional): External ID of the function associated with the call.
+            function_id (int, optional): ID of the function on which the call is made.
+            external_id (str, optional): External ID of the function on which the call is made.
 
         Returns:
             FunctionCall: Function call.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -283,8 +283,8 @@ class FunctionCallsAPI(APIClient):
 
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
-        url = f"/functions/{function_id}/calls/{call_id}"
         if function_external_id:
-            id = self.retrieve(external_id=external_id).id
+            function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
+        url = f"/functions/{function_id}/calls/{call_id}"
         res = self._get(url)
         return FunctionCall._load(res.json(), cognite_client=self._cognite_client)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -232,6 +232,10 @@ class FunctionCallsAPI(APIClient):
     def list(self, function_id: Optional[int] = None, function_external_id: Optional[str] = None) -> FunctionCallList:
         """List all calls associated with a specific function.
 
+        Args:
+            function_id (int, optional): ID of the function associated with the call.
+            external_id (str, optional): External ID of the function associated with the call.
+
         Returns:
             FunctionCallList: List of function calls
         
@@ -262,6 +266,11 @@ class FunctionCallsAPI(APIClient):
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
     ) -> FunctionCall:
         """Retrieve call by id.
+
+        Args:
+            call_id (int): ID of the call.
+            function_id (int, optional): ID of the function associated with the call.
+            external_id (str, optional): External ID of the function associated with the call.
 
         Returns:
             FunctionCall: Function call.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -253,7 +253,7 @@ class FunctionCallsAPI(APIClient):
         """
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
         if function_external_id:
-            id = self.retrieve(external_id=external_id).id
+            function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls"
         res = self._get(url)
         return FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -5,12 +5,16 @@ from zipfile import ZipFile
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient
-from cognite.experimental.data_classes import Function, FunctionCall, FunctionList
+from cognite.experimental.data_classes import Function, FunctionCall, FunctionCallList, FunctionList
 
 
 class FunctionsAPI(APIClient):
     _RESOURCE_PATH = "/functions"
     _LIST_CLASS = FunctionList
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.calls = FunctionCallsAPI(*args, **kwargs)
 
     def create(
         self,
@@ -222,3 +226,65 @@ class FunctionsAPI(APIClient):
         os.chdir(current_dir)
 
         return file.id
+
+
+class FunctionCallsAPI(APIClient):
+    def list(self, function_id: Optional[int] = None, function_external_id: Optional[str] = None) -> FunctionCallList:
+        """List all calls associated with a specific function.
+
+        Returns:
+            FunctionCallList: List of function calls
+        
+        Examples:
+
+            List function calls::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> calls = c.functions.calls.list(function_id=1)
+
+            List function calls directly on a function object::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> func = c.functions.retrieve(id=1)
+                >>> calls = func.list_calls()
+
+        """
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        if function_external_id:
+            id = self.retrieve(external_id=external_id).id
+        url = f"/functions/{function_id}/calls"
+        res = self._get(url)
+        return FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
+
+    def retrieve(
+        self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
+    ) -> FunctionCall:
+        """Retrieve call by id.
+
+        Returns:
+            FunctionCall: Function call.
+        
+        Examples:
+
+            Retrieve function call by id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> call = c.functions.calls.retrieve(call_id=2, function_id=1)
+
+            Retrieve function call directly on a function object::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> func = c.functions.retrieve(id=1)
+                >>> call = func.retrieve_call(id=2)
+
+        """
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        url = f"/functions/{function_id}/calls/{call_id}"
+        if function_external_id:
+            id = self.retrieve(external_id=external_id).id
+        res = self._get(url)
+        return FunctionCall._load(res.json(), cognite_client=self._cognite_client)

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -49,6 +49,12 @@ class Function(CogniteResource):
     def call(self, data=None, asynchronous: bool = False):
         return self._cognite_client.functions.call(id=self.id, data=data, asynchronous=asynchronous)
 
+    def list_calls(self):
+        return self._cognite_client.functions.calls.list(function_id=self.id)
+
+    def retrieve_call(self, id: int):
+        return self._cognite_client.functions.calls.retrieve(call_id=id, function_id=self.id)
+
 
 class FunctionList(CogniteResourceList):
     _RESOURCE = Function
@@ -85,3 +91,8 @@ class FunctionCall(CogniteResource):
         self.status = status
         self.error = error
         self._cognite_client = cognite_client
+
+
+class FunctionCallList(CogniteResourceList):
+    _RESOURCE = FunctionCall
+    _ASSERT_CLASSES = False

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -12,9 +12,9 @@ FILES_API = COGNITE_CLIENT.files
 
 
 EXAMPLE_FUNCTION = {
-    "id": 123456,
+    "id": 1234,
     "name": "myfunction",
-    "externalId": "func-no-123",
+    "externalId": "func-no-1234",
     "description": "my fabulous function",
     "owner": "ola.normann@cognite.com",
     "status": "Ready",
@@ -60,7 +60,7 @@ def mock_functions_create_response(rsps):
 
     files_url = FILES_API._get_base_url_with_base_path() + "/files"
     rsps.add(rsps.POST, files_url, status=201, json=files_response_body)
-    rsps.add(rsps.PUT, "https://upload.here", status=200)
+    rsps.add(rsps.PUT, "https://upload.here", status=201)
 
     functions_url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions"
     rsps.add(rsps.POST, functions_url, status=201, json={"items": [EXAMPLE_FUNCTION]})
@@ -76,17 +76,14 @@ def mock_functions_delete_response(rsps):
     yield rsps
 
 
+BASE_CALL = {"id": 7255309231137124, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Completed"}
+
+
 @pytest.fixture
 def mock_functions_call_completed_response(rsps):
-    response_body_sync = {
-        "id": 7255309231137124,
-        "startTime": 1585925306822,
-        "endTime": 1585925310822,
-        "response": "Hello World!",
-        "status": "Completed",
-    }
-    response_body_async = response_body_sync.copy()
-    del response_body_async["response"]
+    response_body_async = BASE_CALL.copy()
+    response_body_sync = BASE_CALL.copy()
+    response_body_sync["response"] = "Hello World!"
 
     url_sync = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
     url_async = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/async_call"
@@ -99,15 +96,10 @@ def mock_functions_call_completed_response(rsps):
 
 @pytest.fixture
 def mock_functions_call_by_external_id(mock_functions_retrieve_response):
-    response_body = {
-        "id": 7255309231137124,
-        "startTime": 1585925306822,
-        "endTime": 1585925310822,
-        "response": "Hello World!",
-        "status": "Completed",
-    }
+    response_body = BASE_CALL.copy()
+    response_body["response"] = "Hello World!"
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/123456/call"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
     rsps = mock_functions_retrieve_response
     rsps.add(rsps.POST, url, status=201, json=response_body)
 
@@ -116,13 +108,9 @@ def mock_functions_call_by_external_id(mock_functions_retrieve_response):
 
 @pytest.fixture
 def mock_functions_call_failed_response(rsps):
-    response_body = {
-        "id": 7255309231137124,
-        "startTime": 1585925306822,
-        "endTime": 1585925310822,
-        "status": "Failed",
-        "error": {"message": "some message", "trace": "some stack trace"},
-    }
+    response_body = BASE_CALL.copy()
+    response_body["status"] = "Failed"
+    response_body["error"] = ({"message": "some message", "trace": "some stack trace"},)
 
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
     rsps.add(rsps.POST, url, status=201, json=response_body)
@@ -132,7 +120,8 @@ def mock_functions_call_failed_response(rsps):
 
 @pytest.fixture
 def mock_functions_call_timeout_response(rsps):
-    response_body = {"id": 7255309231137124, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Timeout"}
+    response_body = BASE_CALL.copy()
+    response_body["status"] = "Timeout"
 
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
     rsps.add(rsps.POST, url, status=201, json=response_body)
@@ -218,7 +207,7 @@ class TestFunctionsAPI:
         assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_function_call_by_external_id(self, mock_functions_call_by_external_id):
-        res = FUNCTIONS_API.call(external_id="func-no-123")
+        res = FUNCTIONS_API.call(external_id="func-no-1234")
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_by_external_id.calls[1].response.json() == res.dump(camel_case=True)
 


### PR DESCRIPTION
This PR adds a new `FunctionCallsAPI` under `FunctionsAPI` and also implements the methods `FunctionCallsAPI.retrieve()` and `FunctionCallsAPI.list()`. They are used as follows:
```
from cognite.experimental import CogniteClient
c = CogniteClient()
call = c.functions.calls.retrieve(call_id=456, function_id=123)
calls = c.functions.calls.list(function_id=123)
```
where `call` and `calls` are objects of type `FunctionCall` and `FunctionCallList`, respectively. The keyword argument `function_id` can in both cases be replaced by `function_external_id`.

Function calls can also be retrieve/listed directly on a `Function` object:
```
func = c.functions.retrieve(id=123)
call = func.retrieve_call(call_id=456)
calls = func.list_calls()
```