### PR TITLE
[CDF-3768] Add FunctionCallsAPI.logs()

### DIFF
--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -8,11 +8,6 @@ from cognite.client._api_client import APIClient
 from cognite.experimental.data_classes import Function, FunctionCall, FunctionCallList, FunctionCallLog, FunctionList
 
 
-def _add_function_id_to_calls(calls: FunctionCallList, function_id: int) -> None:
-    for call in calls:
-        call._function_id = function_id
-
-
 class FunctionsAPI(APIClient):
     _RESOURCE_PATH = "/functions"
     _LIST_CLASS = FunctionList
@@ -211,9 +206,7 @@ class FunctionsAPI(APIClient):
         if data:
             body = {"data": data}
         res = self._post(url, json=body)
-        call = FunctionCall._load(res.json(), cognite_client=self._cognite_client)
-        _add_function_id_to_calls([call], id)
-        return call
+        return FunctionCall._load(res.json(), function_id=id, cognite_client=self._cognite_client)
 
     def _zip_and_upload_folder(self, folder, name) -> int:
         current_dir = os.getcwd()
@@ -267,9 +260,7 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls"
         res = self._get(url)
-        calls = FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
-        _add_function_id_to_calls(calls, function_id)
-        return calls
+        return FunctionCallList._load(res.json()["items"], function_id=function_id, cognite_client=self._cognite_client)
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
@@ -305,9 +296,7 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls/{call_id}"
         res = self._get(url)
-        call = FunctionCall._load(res.json(), cognite_client=self._cognite_client)
-        _add_function_id_to_calls([call], function_id)
-        return call
+        return FunctionCall._load(res.json(), function_id=function_id, cognite_client=self._cognite_client)
 
     def logs(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -5,7 +5,12 @@ from zipfile import ZipFile
 
 from cognite.client import utils
 from cognite.client._api_client import APIClient
-from cognite.experimental.data_classes import Function, FunctionCall, FunctionCallList, FunctionList
+from cognite.experimental.data_classes import Function, FunctionCall, FunctionCallList, FunctionCallLog, FunctionList
+
+
+def _add_function_id_to_calls(calls: FunctionCallList, function_id: int) -> None:
+    for call in calls:
+        call._function_id = function_id
 
 
 class FunctionsAPI(APIClient):
@@ -206,7 +211,9 @@ class FunctionsAPI(APIClient):
         if data:
             body = {"data": data}
         res = self._post(url, json=body)
-        return FunctionCall._load(res.json())
+        call = FunctionCall._load(res.json(), cognite_client=self._cognite_client)
+        _add_function_id_to_calls([call], id)
+        return call
 
     def _zip_and_upload_folder(self, folder, name) -> int:
         current_dir = os.getcwd()
@@ -260,7 +267,9 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls"
         res = self._get(url)
-        return FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
+        calls = FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
+        _add_function_id_to_calls(calls, function_id)
+        return calls
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
@@ -296,4 +305,42 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls/{call_id}"
         res = self._get(url)
-        return FunctionCall._load(res.json(), cognite_client=self._cognite_client)
+        call = FunctionCall._load(res.json(), cognite_client=self._cognite_client)
+        _add_function_id_to_calls([call], function_id)
+        return call
+
+    def logs(
+        self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
+    ) -> FunctionCallLog:
+        """Retrieve logs for function call.
+
+        Args:
+            call_id (int): ID of the call.
+            function_id (int, optional): ID of the function on which the call is made.
+            external_id (str, optional): External ID of the function on which the call is made.
+
+        Returns:
+            FunctionCallLog: Log for the function call.
+        
+        Examples:
+
+            Retrieve function call logs by call ID::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> logs = c.functions.calls.logs(call_id=2, function_id=1)
+
+            Retrieve function call logs directly on a call object::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> call = c.functions.calls.retrieve(call_id=2, function_id=1)
+                >>> logs = call.logs()
+
+        """
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        if function_external_id:
+            function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
+        url = f"/functions/{function_id}/calls/{call_id}/logs"
+        res = self._get(url)
+        return FunctionCallLog._load(res.json()["items"])

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -240,8 +240,8 @@ class FunctionCallsAPI(APIClient):
         """List all calls associated with a specific function.
 
         Args:
-            function_id (int, optional): ID of the function on which the calls are made.
-            external_id (str, optional): External ID of the function on which the calls are made.
+            function_id (int, optional): ID of the function on which the calls were made.
+            external_id (str, optional): External ID of the function on which the calls were made.
 
         Returns:
             FunctionCallList: List of function calls
@@ -278,8 +278,8 @@ class FunctionCallsAPI(APIClient):
 
         Args:
             call_id (int): ID of the call.
-            function_id (int, optional): ID of the function on which the call is made.
-            external_id (str, optional): External ID of the function on which the call is made.
+            function_id (int, optional): ID of the function on which the call was made.
+            external_id (str, optional): External ID of the function on which the call was made.
 
         Returns:
             FunctionCall: Function call.
@@ -316,8 +316,8 @@ class FunctionCallsAPI(APIClient):
 
         Args:
             call_id (int): ID of the call.
-            function_id (int, optional): ID of the function on which the call is made.
-            external_id (str, optional): External ID of the function on which the call is made.
+            function_id (int, optional): ID of the function on which the call was made.
+            external_id (str, optional): External ID of the function on which the call was made.
 
         Returns:
             FunctionCallLog: Log for the function call.

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -82,6 +82,7 @@ class FunctionCall(CogniteResource):
         response: str = None,
         status: str = None,
         error: dict = None,
+        function_id: int = None,
         cognite_client=None,
     ):
         self.id = id
@@ -90,9 +91,32 @@ class FunctionCall(CogniteResource):
         self.response = response
         self.status = status
         self.error = error
+        self._function_id = function_id
         self._cognite_client = cognite_client
+
+    def logs(self):
+        return self._cognite_client.functions.calls.logs(call_id=self.id, function_id=self._function_id)
 
 
 class FunctionCallList(CogniteResourceList):
     _RESOURCE = FunctionCall
+    _ASSERT_CLASSES = False
+
+
+class FunctionCallLogEntry(CogniteResource):
+    """A log entry for a function call.
+
+    Args:
+        timestamp (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        message (str): Single line from stdout / stderr.
+    """
+
+    def __init__(self, timestamp: int = None, message: str = None, cognite_client=None):
+        self.timestamp = timestamp
+        self.message = message
+        self._cognite_client = cognite_client
+
+
+class FunctionCallLog(CogniteResourceList):
+    _RESOURCE = FunctionCallLogEntry
     _ASSERT_CLASSES = False

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List, Union
 
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
 
@@ -97,10 +97,24 @@ class FunctionCall(CogniteResource):
     def logs(self):
         return self._cognite_client.functions.calls.logs(call_id=self.id, function_id=self._function_id)
 
+    @classmethod
+    def _load(cls, resource: Union[Dict, str], function_id: int = None, cognite_client=None):
+        instance = super()._load(resource, cognite_client=cognite_client)
+        if function_id:
+            instance._function_id = function_id
+        return instance
+
 
 class FunctionCallList(CogniteResourceList):
     _RESOURCE = FunctionCall
     _ASSERT_CLASSES = False
+
+    @classmethod
+    def _load(cls, resource: Union[List, str], function_id: int, cognite_client=None):
+        instance = super()._load(resource, cognite_client=cognite_client)
+        for obj in instance:
+            obj._function_id = function_id
+        return instance
 
 
 class FunctionCallLogEntry(CogniteResource):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -77,7 +77,7 @@ def mock_functions_delete_response(rsps):
     yield rsps
 
 
-BASE_CALL = {"id": 7255309231137124, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Completed"}
+BASE_CALL = {"id": 5678, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Completed"}
 
 
 @pytest.fixture
@@ -224,8 +224,7 @@ class TestFunctionsAPI:
 
 
 @pytest.fixture
-def mock_function_calls_list_response(mock_functions_retrieve_response):
-    rsps = mock_functions_retrieve_response
+def mock_function_calls_list_response(rsps):
     response_body = {"items": [BASE_CALL.copy()]}
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/calls"
     rsps.assert_all_requests_are_fired = False
@@ -235,8 +234,7 @@ def mock_function_calls_list_response(mock_functions_retrieve_response):
 
 
 @pytest.fixture
-def mock_function_calls_retrieve_response(mock_functions_retrieve_response):
-    rsps = mock_functions_retrieve_response
+def mock_function_calls_retrieve_response(rsps):
     response_body = BASE_CALL.copy()
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/calls/5678"
     rsps.assert_all_requests_are_fired = False
@@ -246,8 +244,7 @@ def mock_function_calls_retrieve_response(mock_functions_retrieve_response):
 
 
 @pytest.fixture
-def mock_function_call_logs_response(mock_functions_retrieve_response):
-    rsps = mock_functions_retrieve_response
+def mock_function_call_logs_response(rsps):
     response_body = {
         "items": [
             {"timestamp": 1585925306822, "message": "message 1"},
@@ -267,6 +264,7 @@ class TestFunctionCallsAPI:
         assert isinstance(res, FunctionCallList)
         assert mock_function_calls_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
+    @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_list_calls_by_function_external_id(self, mock_function_calls_list_response):
         res = FUNCTION_CALLS_API.list(function_external_id="func-no-1234")
         assert isinstance(res, FunctionCallList)
@@ -277,6 +275,7 @@ class TestFunctionCallsAPI:
         assert isinstance(res, FunctionCall)
         assert mock_function_calls_retrieve_response.calls[0].response.json() == res.dump(camel_case=True)
 
+    @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_retrieve_call_by_function_external_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=5678, function_external_id="func-no-1234")
         assert isinstance(res, FunctionCall)
@@ -287,7 +286,30 @@ class TestFunctionCallsAPI:
         assert isinstance(res, FunctionCallLog)
         assert mock_function_call_logs_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
+    @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_function_call_logs_by_function_external_id(self, mock_function_call_logs_response):
         res = FUNCTION_CALLS_API.logs(call_id=5678, function_external_id="func-no-1234")
         assert isinstance(res, FunctionCallLog)
         assert mock_function_call_logs_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+
+    @pytest.mark.usefixtures("mock_function_calls_retrieve_response")
+    def test_get_logs_on_retrieved_call_object(self, mock_function_call_logs_response):
+        call = FUNCTION_CALLS_API.retrieve(call_id=5678, function_id=1234)
+        logs = call.logs()
+        assert isinstance(logs, FunctionCallLog)
+        assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)
+
+    @pytest.mark.usefixtures("mock_function_calls_list_response")
+    def test_get_logs_on_listed_call_object(self, mock_function_call_logs_response):
+        calls = FUNCTION_CALLS_API.list(function_id=1234)
+        call = calls[0]
+        logs = call.logs()
+        assert isinstance(logs, FunctionCallLog)
+        assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)
+
+    @pytest.mark.usefixtures("mock_functions_call_completed_response")
+    def test_get_logs_on_created_call_object(self, mock_function_call_logs_response):
+        call = FUNCTIONS_API.call(id=1234)
+        logs = call.logs()
+        assert isinstance(logs, FunctionCallLog)
+        assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -1,0 +1,21 @@
+import pytest
+
+from cognite.experimental.data_classes import FunctionCall, FunctionCallList
+
+CALL_RESPONSE = {"id": 5678, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Completed"}
+
+
+class TestFunctionCall:
+    def test_load(self):
+        function_id = 1234
+        call = FunctionCall._load(CALL_RESPONSE, function_id=function_id)
+        assert function_id == call._function_id
+        assert CALL_RESPONSE == call.dump(camel_case=True)
+
+
+class TestFunctionCallList:
+    def test_load(self):
+        function_id = 1234
+        calls = FunctionCallList._load([CALL_RESPONSE], function_id=function_id)
+        assert function_id == calls[0]._function_id
+        assert [CALL_RESPONSE] == calls.dump(camel_case=True)


### PR DESCRIPTION
This PR adds the method `FunctionCallsAPI.logs()` which returns logs for a specific function call. It is used as follows:
```
from cognite.experimental import CogniteClient
c = CogniteClient()
logs = c.functions.calls.logs(call_id=456, function_id=123)
```
where the logs looks like:
````
print(logs)
[
    {
        "timestamp": "2020-04-07 17:03:08",
        "message": "Started function execution"      
    },
    {
        "timestamp": "2020-04-07 17:03:12",
        "message": "Finished function execution"      
    },
]
````
Optionally, the argument `function_id` can be replaced by `function_external_id`.

The logs can also be retrieved directly from a `FunctionCall` object, like so:
```
func = c.functions.create(name="myfunction", folder="path/to/code")
call = func.call()
logs = call.logs()
```