### PR TITLE
[CDF-3927] Allow function to be deployed from code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-=======
 # Changelog
 All notable changes to this project will be documented in this file.
 
@@ -12,6 +11,11 @@ Changes are grouped as follows
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
+
+## Unreleased
+
+### Added
+- Argument `function_handle` to `FunctionsAPI.create()`, which can be used to create a function directly from code.
 
 ## [0.5.0] - 2020-04-08
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -130,6 +130,30 @@ def mock_functions_call_timeout_response(rsps):
     yield rsps
 
 
+@pytest.fixture
+def function_handle():
+    def handle(data, client, secrets):
+        pass
+
+    return handle
+
+
+@pytest.fixture
+def function_handle_illegal_name():
+    def func(data, client, secrets):
+        pass
+
+    return func
+
+
+@pytest.fixture
+def function_handle_illegal_argument():
+    def handle(client, input):
+        pass
+
+    return handle
+
+
 class TestFunctionsAPI:
     def test_create_with_path(self, mock_functions_create_response):
         folder = os.path.join(os.path.dirname(__file__), "function_code")
@@ -143,6 +167,24 @@ class TestFunctionsAPI:
 
         assert isinstance(res, Function)
         assert mock_functions_create_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_create_with_function_handle(self, mock_functions_create_response, function_handle):
+        res = FUNCTIONS_API.create(name="myfunction", function_handle=function_handle)
+
+        assert isinstance(res, Function)
+        assert mock_functions_create_response.calls[2].response.json()["items"][0] == res.dump(camel_case=True)
+
+    def test_create_with_function_handle_with_illegal_name_raises(self, function_handle_illegal_name):
+        with pytest.raises(TypeError):
+            FUNCTIONS_API.create(name="myfunction", function_handle=function_handle_illegal_name)
+
+    def test_create_with_function_handle_with_illegal_argument_raises(self, function_handle_illegal_argument):
+        with pytest.raises(TypeError):
+            FUNCTIONS_API.create(name="myfunction", function_handle=function_handle_illegal_argument)
+
+    def test_create_with_handle_function_and_file_id_raises(self, mock_functions_create_response, function_handle):
+        with pytest.raises(TypeError):
+            FUNCTIONS_API.create(name="myfunction", function_handle=function_handle, file_id=1234)
 
     def test_create_with_path_and_file_id_raises(self, mock_functions_create_response):
         with pytest.raises(TypeError):


### PR DESCRIPTION
This PR makes it possible to deploy a function from code. The function must be named `handle` and can have arguments that are a subset of `(data, client, secrets)`:
```
def handle(data):
      return data["value"]*2
```
Then you create a function as follows:
```
from cognite.experimental import CogniteClient
c = CogniteClient()
func = c.functions.create(name="myfunc", function_handle=handle)
```