### PR TITLE
[CDF-3923] Add Schedules to Function SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+### Added
+- A `FunctionSchedule` class and corresponding api attached to the `Functions` api to interact with function schedules. 
+Function schedules can now also be listed using the `Function` object through the `list_schedules` method. 
+
 ## [0.5.1] - 2020-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.5.2] - 2020-04-16
+
 ### Added
 - A `FunctionSchedule` class and corresponding api attached to the `Functions` api to interact with function schedules. 
 Function schedules can now also be listed using the `Function` object through the `list_schedules` method. 

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -449,9 +449,10 @@ class FunctionSchedulesAPI(APIClient):
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
                 >>> schedule = c.functions.schedules.create(
-                    name= "my-schedule",
+                    name= "My schedule",
                     function_external_id="my-external-id",
-                    cron_expression="*/5 * * * *", description="Hi")
+                    cron_expression="*/5 * * * *",
+                    description="This schedule does magic stuff.")
 
         """
         json = {

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -435,9 +435,9 @@ class FunctionSchedulesAPI(APIClient):
         Args:
             name (str): Name of the schedule.
             function_external_id (str): External id of the function.
-            description (optional, str): Description of the schedule.
+            description (str): Description of the schedule.
             cron_expression (str): Cron expression.
-            data (Dict): Data to be passed to the scheduled run.
+            data (optional, Dict): Data to be passed to the scheduled run.
 
         Returns:
             FunctionSchedule: Created function schedule.
@@ -448,9 +448,10 @@ class FunctionSchedulesAPI(APIClient):
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> schedule = c.functions.schedules.create(name= "my-schedule",
-                function_external_id="my-external-id",
-                cron_expression="*/5 * * * *", description="Hi")
+                >>> schedule = c.functions.schedules.create(
+                    name= "my-schedule",
+                    function_external_id="my-external-id",
+                    cron_expression="*/5 * * * *", description="Hi")
 
         """
         json = {

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -354,8 +354,8 @@ class FunctionCallsAPI(APIClient):
 
 
 class FunctionSchedulesAPI(APIClient):
-    def list(self) -> FunctionCallList:
-        """`List all schedules associated with a specific project. `_
+    def list(self) -> FunctionSchedulesList:
+        """`List all schedules associated with a specific project. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-schedules>`_
 
         Returns:
             FunctionSchedulesList: List of function schedules
@@ -381,10 +381,10 @@ class FunctionSchedulesAPI(APIClient):
         description: str,
         data: Union[Dict, None] = None,
     ) -> FunctionSchedule:
-        """`Create a schedule associated with a specific project. `_
+        """`Create a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules>`_
 
         Returns:
-            FunctionSchedule: List of function schedules
+            FunctionSchedule: Created function schedule.
 
         Examples:
 
@@ -392,7 +392,7 @@ class FunctionSchedulesAPI(APIClient):
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> schedules = c.functions.schedules.create(name= "my-schedule",
+                >>> schedule = c.functions.schedules.create(name= "my-schedule",
                 function_external_id="user/hello-cognite/hello-cognite:latest",
                 cron_expression="*/5 * * * *", description="Hi")
 
@@ -410,10 +410,23 @@ class FunctionSchedulesAPI(APIClient):
         }
         url = f"/functions/schedules"
         res = self._post(url, json=json)
-        return FunctionSchedulesList._load(res.json()["items"])
+        return FunctionSchedule._load(res.json()["items"][0])
 
     def delete(self, id: int):
+        """`Delete a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules-delete>`_
+
+        Returns:
+            FunctionSchedule: Delete function schedule.
+
+        Examples:
+
+            List function calls::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> schedule = c.functions.schedules.delete(id= 123)
+
+        """
         json = {"items": [{"id": id,}]}
         url = f"/functions/schedules/delete"
-        res = self._post(url, json=json)
-        return res
+        self._post(url, json=json)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -428,15 +428,15 @@ class FunctionSchedulesAPI(APIClient):
         function_external_id: str,
         cron_expression: str,
         description: Optional[str] = "",
-        data: Union[Dict, None] = None,
+        data: Optional[Dict] = None,
     ) -> FunctionSchedule:
         """`Create a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules>`_
 
         Args:
-            name (str): Name of the function.
+            name (str): Name of the schedule.
             function_external_id (str): External id of the function.
-            description (optional, str): Description of the function.
-            cron_expression (str): Cron expression (see e.g. http://www.cronmaker.com)
+            description (optional, str): Description of the schedule.
+            cron_expression (str): Cron expression.
             data (Dict): Data to be passed to the scheduled run.
 
         Returns:

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -427,7 +427,7 @@ class FunctionSchedulesAPI(APIClient):
         name: str,
         function_external_id: str,
         cron_expression: str,
-        description: Optional[str] = "",
+        description: str = "",
         data: Optional[Dict] = None,
     ) -> FunctionSchedule:
         """`Create a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules>`_
@@ -476,7 +476,7 @@ class FunctionSchedulesAPI(APIClient):
             id (int): Id of the schedule
 
         Returns:
-            FunctionSchedule: Delete function schedule.
+            None
 
         Examples:
 
@@ -484,7 +484,7 @@ class FunctionSchedulesAPI(APIClient):
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> c.functions.schedules.delete(id= 123)
+                >>> c.functions.schedules.delete(id = 123)
 
         """
         json = {"items": [{"id": id,}]}

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -378,10 +378,17 @@ class FunctionSchedulesAPI(APIClient):
         name: str,
         function_external_id: str,
         cron_expression: str,
-        description: str,
+        description: Optional[str] = "",
         data: Union[Dict, None] = None,
     ) -> FunctionSchedule:
         """`Create a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules>`_
+
+        Args:
+            name (str): Name of the function.
+            function_external_id (str): External id of the function.
+            description (optional, str): Description of the function.
+            cron_expression (str): Cron expression (see e.g. http://www.cronmaker.com)
+            data (Dict): Data to be passed to the scheduled run.
 
         Returns:
             FunctionSchedule: Created function schedule.
@@ -393,7 +400,7 @@ class FunctionSchedulesAPI(APIClient):
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
                 >>> schedule = c.functions.schedules.create(name= "my-schedule",
-                function_external_id="user/hello-cognite/hello-cognite:latest",
+                function_external_id="my-external-id",
                 cron_expression="*/5 * * * *", description="Hi")
 
         """
@@ -404,7 +411,7 @@ class FunctionSchedulesAPI(APIClient):
                     "description": description,
                     "functionExternalId": function_external_id,
                     "cronExpression": cron_expression,
-                    "data": {},
+                    "data": data,
                 }
             ]
         }
@@ -414,6 +421,9 @@ class FunctionSchedulesAPI(APIClient):
 
     def delete(self, id: int) -> None:
         """`Delete a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules-delete>`_
+
+        Args:
+            id (int): Id of the schedule
 
         Returns:
             FunctionSchedule: Delete function schedule.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -362,7 +362,7 @@ class FunctionSchedulesAPI(APIClient):
 
         Examples:
 
-            List function calls::
+            List function schedules::
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
@@ -388,7 +388,7 @@ class FunctionSchedulesAPI(APIClient):
 
         Examples:
 
-            List function calls::
+            Create function schedule::
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
@@ -412,7 +412,7 @@ class FunctionSchedulesAPI(APIClient):
         res = self._post(url, json=json)
         return FunctionSchedule._load(res.json()["items"][0])
 
-    def delete(self, id: int):
+    def delete(self, id: int) -> None:
         """`Delete a schedule associated with a specific project. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions-schedules-delete>`_
 
         Returns:
@@ -420,11 +420,11 @@ class FunctionSchedulesAPI(APIClient):
 
         Examples:
 
-            List function calls::
+            Delete function schedule::
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
-                >>> schedule = c.functions.schedules.delete(id= 123)
+                >>> c.functions.schedules.delete(id= 123)
 
         """
         json = {"items": [{"id": id,}]}

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -66,9 +66,9 @@ class FunctionSchedule(CogniteResource):
 
     Args:
         id (int): Id of the schedule.
-        name (str): Name of the function.
+        name (str): Name of the function schedule.
         function_external_id (str): External id of the function.
-        description (str): Description of the function.
+        description (str): Description of the function schedule.
         cron_expression (str): Cron expression
         created_time (int): Created time in UNIX.
         data (Dict): Data to be passed to the scheduled run.

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -70,7 +70,7 @@ class FunctionSchedule(CogniteResource):
         function_external_id (str): External id of the function.
         description (str): Description of the function schedule.
         cron_expression (str): Cron expression
-        created_time (int): Created time in UNIX.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
         data (Dict): Data to be passed to the scheduled run.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -72,7 +72,6 @@ class FunctionSchedule(CogniteResource):
         cron_expression (str): Cron expression
         created_time (int): Created time in UNIX.
         data (Dict): Data to be passed to the scheduled run.
-        when (str): When the schedule runs in human readable format.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """
 
@@ -94,6 +93,7 @@ class FunctionSchedule(CogniteResource):
         self.cron_expression = cron_expression
         self.created_time = created_time
         self.data = data
+        self._cognite_client = cognite_client
 
 
 class FunctionSchedulesList(CogniteResourceList):

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -66,6 +66,8 @@ class FunctionSchedule(CogniteResource):
         description (str): Description of the function.
         cron_expression (str): Cron expression
         created_time (int): Created time in UNIX.
+        data (Dict): Data to be passed to the scheduled run.
+        when (str): When the schedule runs in human readable format.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """
 
@@ -78,6 +80,7 @@ class FunctionSchedule(CogniteResource):
         created_time: int = None,
         cron_expression: str = None,
         data: Dict = None,
+        when: str = None,
         cognite_client=None,
     ):
         self.id = id
@@ -87,6 +90,7 @@ class FunctionSchedule(CogniteResource):
         self.cron_expression = cron_expression
         self.created_time = created_time
         self.data = data
+        self.when = when
 
 
 class FunctionSchedulesList(CogniteResourceList):

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -85,7 +85,6 @@ class FunctionSchedule(CogniteResource):
         created_time: int = None,
         cron_expression: str = None,
         data: Dict = None,
-        when: str = None,
         cognite_client=None,
     ):
         self.id = id
@@ -95,7 +94,6 @@ class FunctionSchedule(CogniteResource):
         self.cron_expression = cron_expression
         self.created_time = created_time
         self.data = data
-        self.when = when
 
 
 class FunctionSchedulesList(CogniteResourceList):

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -52,6 +52,11 @@ class Function(CogniteResource):
     def list_calls(self):
         return self._cognite_client.functions.calls.list(function_id=self.id)
 
+    def list_schedules(self):
+        all_schedules = self._cognite_client.functions.schedules.list()
+        function_schedules = filter(lambda f: f.function_external_id == self.external_id, all_schedules)
+        return function_schedules
+
     def retrieve_call(self, id: int):
         return self._cognite_client.functions.calls.retrieve(call_id=id, function_id=self.id)
 

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -55,7 +55,7 @@ class Function(CogniteResource):
     def list_schedules(self):
         all_schedules = self._cognite_client.functions.schedules.list()
         function_schedules = filter(lambda f: f.function_external_id == self.external_id, all_schedules)
-        return function_schedules
+        return list(function_schedules)
 
     def retrieve_call(self, id: int):
         return self._cognite_client.functions.calls.retrieve(call_id=id, function_id=self.id)

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -56,6 +56,44 @@ class Function(CogniteResource):
         return self._cognite_client.functions.calls.retrieve(call_id=id, function_id=self.id)
 
 
+class FunctionSchedule(CogniteResource):
+    """A representation of a Cognite Function Schedule.
+
+    Args:
+        id (int): Id of the function.
+        name (str): Name of the function.
+        function_external_id (str): External id of the function.
+        description (str): Description of the function.
+        cron_expression (str): Cron expression
+        created_time (int): Created time in UNIX.
+        cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
+    """
+
+    def __init__(
+        self,
+        id: int = None,
+        name: str = None,
+        function_external_id: str = None,
+        description: str = None,
+        created_time: int = None,
+        cron_expression: str = None,
+        data: Dict = None,
+        cognite_client=None,
+    ):
+        self.id = id
+        self.name = name
+        self.function_external_id = function_external_id
+        self.description = description
+        self.cron_expression = cron_expression
+        self.created_time = created_time
+        self.data = data
+
+
+class FunctionSchedulesList(CogniteResourceList):
+    _RESOURCE = FunctionSchedule
+    _ASSERT_CLASSES = False
+
+
 class FunctionList(CogniteResourceList):
     _RESOURCE = Function
     _ASSERT_CLASSES = False

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -65,7 +65,7 @@ class FunctionSchedule(CogniteResource):
     """A representation of a Cognite Function Schedule.
 
     Args:
-        id (int): Id of the function.
+        id (int): Id of the schedule.
         name (str): Name of the function.
         function_external_id (str): External id of the function.
         description (str): Description of the function.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.5.1"
+version = "0.5.2"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -3,12 +3,20 @@ import os
 import pytest
 
 from cognite.experimental import CogniteClient
-from cognite.experimental.data_classes import Function, FunctionCall, FunctionCallList, FunctionCallLog, FunctionList
+from cognite.experimental.data_classes import (
+    Function,
+    FunctionCall,
+    FunctionCallList,
+    FunctionCallLog,
+    FunctionList,
+    FunctionSchedulesList,
+)
 from tests.utils import jsgz_load
 
 COGNITE_CLIENT = CogniteClient()
 FUNCTIONS_API = COGNITE_CLIENT.functions
 FUNCTION_CALLS_API = FUNCTIONS_API.calls
+FUNCTION_SCHEDULES_API = FUNCTIONS_API.schedules
 FILES_API = COGNITE_CLIENT.files
 
 
@@ -256,6 +264,46 @@ def mock_function_call_logs_response(rsps):
     rsps.add(rsps.GET, url, status=200, json=response_body)
 
     yield rsps
+
+
+@pytest.fixture
+def mock_function_schedules_list_response(rsps):
+    response_body = {
+        "items": [
+            {
+                "createdTime": 1586944839659,
+                "cronExpression": "*/5 * * * *",
+                "data": {},
+                "description": "Hi",
+                "functionExternalId": "matzhaugen/hello-cognite/hello-cognite:latest",
+                "id": 8012683333564363,
+                "name": "my-schedule2",
+                "when": "Every 5 minutes",
+            },
+            {
+                "createdTime": 1586944852871,
+                "cronExpression": "*/5 * * * *",
+                "data": {},
+                "description": "Hi",
+                "functionExternalId": "matzhaugen/hello-cognite/hello-cognite:latest",
+                "id": 835726202545567,
+                "name": "my-schedule2",
+                "when": "Every 5 minutes",
+            },
+        ]
+    }
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules"
+    rsps.assert_all_requests_are_fired = False
+    rsps.add(rsps.GET, url, status=200, json=response_body)
+
+    yield rsps
+
+
+class TestFunctionSchedulesAPI:
+    def test_list_schedules(self, mock_function_schedules_list_response):
+        res = FUNCTION_SCHEDULES_API.list()
+        assert isinstance(res, FunctionSchedulesList)
+        assert mock_function_calls_list_response.list[0].response.json()["items"] == res.dump(camel_case=True)
 
 
 class TestFunctionCallsAPI:

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -345,7 +345,6 @@ def mock_function_schedules_response(rsps):
 @pytest.fixture
 def mock_function_schedules_response_with_data(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules"
-    rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE2]})
 
     yield rsps
@@ -354,7 +353,6 @@ def mock_function_schedules_response_with_data(rsps):
 @pytest.fixture
 def mock_function_schedules_delete_response(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules/delete"
-    rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.POST, url, status=200, json={})
 
     yield rsps
@@ -364,7 +362,9 @@ class TestFunctionSchedulesAPI:
     def test_list_schedules(self, mock_function_schedules_response):
         res = FUNCTION_SCHEDULES_API.list()
         assert isinstance(res, FunctionSchedulesList)
-        assert mock_function_schedules_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        expected = mock_function_schedules_response.calls[0].response.json()["items"]
+        expected[0].pop("when")
+        assert expected == res.dump(camel_case=True)
 
     def test_create_schedules(self, mock_function_schedules_response):
         res = FUNCTION_SCHEDULES_API.create(
@@ -374,7 +374,9 @@ class TestFunctionSchedulesAPI:
             description="Hi",
         )
         assert isinstance(res, FunctionSchedule)
-        assert mock_function_schedules_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+        expected = mock_function_schedules_response.calls[0].response.json()["items"][0]
+        expected.pop("when")
+        assert expected == res.dump(camel_case=True)
 
     def test_create_schedules_with_data(self, mock_function_schedules_response_with_data):
         res = FUNCTION_SCHEDULES_API.create(
@@ -385,9 +387,9 @@ class TestFunctionSchedulesAPI:
             data={"value": 2},
         )
         assert isinstance(res, FunctionSchedule)
-        assert mock_function_schedules_response_with_data.calls[0].response.json()["items"][0] == res.dump(
-            camel_case=True
-        )
+        expected = mock_function_schedules_response_with_data.calls[0].response.json()["items"][0]
+        expected.pop("when")
+        assert expected == res.dump(camel_case=True)
 
     def test_delete_schedules(self, mock_function_schedules_delete_response):
         res = FUNCTION_SCHEDULES_API.delete(id=8012683333564363)


### PR DESCRIPTION
## Include scheduling functionality in the Cognite Functions SDK
### Examples
```
from cognite.experimental import CogniteClient
c = CogniteClient()
schedules = c.functions.schedules.list()
schedule = c.functions.schedules.create(name= "my-schedule",
                function_external_id="user/hello-cognite/hello-cognite:latest",
                cron_expression="*/5 * * * *", description="Hi")
c.functions.schedules.delete(id= 123)

my_function = c.functions.create(..., external_id="foo")
function_schedules = my_function.list_schedules()

```

