### PR TITLE
[CDF-4863] Add error to data class Function and bump to version 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.5.4] - 2020-04-21
+
+### Changed
+- Data class `Function` now has the additional attribute `error`.
+
 ## [0.5.3] - 2020-04-16
 
 ### Added

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -17,6 +17,7 @@ class Function(CogniteResource):
         created_time (int): Created time in UNIX.
         api_key (str): Api key attached to the function.
         secrets (Dict[str, str]): Secrets attached to the function ((key, value) pairs).
+        error(Dict[str, str]): Dictionary with keys "error_message" and "trace", which is populated if deployment fails.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """
 
@@ -32,6 +33,7 @@ class Function(CogniteResource):
         created_time: int = None,
         api_key: str = None,
         secrets: Dict = None,
+        error: Dict = None,
         cognite_client=None,
     ):
         self.id = id
@@ -44,6 +46,7 @@ class Function(CogniteResource):
         self.created_time = created_time
         self.api_key = api_key
         self.secrets = secrets
+        self.error = error
         self._cognite_client = cognite_client
 
     def call(self, data=None, asynchronous: bool = False):

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -17,7 +17,7 @@ class Function(CogniteResource):
         created_time (int): Created time in UNIX.
         api_key (str): Api key attached to the function.
         secrets (Dict[str, str]): Secrets attached to the function ((key, value) pairs).
-        error(Dict[str, str]): Dictionary with keys "error_message" and "trace", which is populated if deployment fails.
+        error(Dict[str, str]): Dictionary with keys "message" and "trace", which is populated if deployment fails.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.5.4"
+version = "0.5.5"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.5.3"
+version = "0.5.4"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
This is due to the following change in the functions API:
https://github.com/cognitedata/context-api/pull/395