### PR TITLE
[CDF 5678] BUMP package: add checks to function folder and module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes are grouped as follows
 ## [0.5.5] - 2020-04-27
 
 ### Added
-- Added handler checks to functions to the functions API module.
+- Added checks that verifies that the function handler in an uploaded funtions is correctly constructed.
 
 ## [0.5.5] - 2020-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,16 @@ Changes are grouped as follows
 ## [0.5.7] - 2020-04-29
 
 ### Added
-- Data classes for contextualization models and job now include time stamps for request_timestamp, start_timestamp, status_timestamp.
 - Added checks that verify that the function handler in an uploaded function is correctly constructed.
-- Unstructured search endpoints added in client.files.unstructured.
-
-## [0.5.6] - 2020-04-28
 
 ### Fixed
 - `FunctionSchedulesAPI.create()` works without providing the `data` argument.
+
+## [0.5.6] - 2020-04-28
+
+### Added 
+- Data classes for contextualization models and job now include time stamps for request_timestamp, start_timestamp, status_timestamp.
+- Unstructured search endpoints added in client.files.unstructured.
 
 ## [0.5.5] - 2020-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ### Added
 - Data classes for contextualization models and job now include time stamps for request_timestamp, start_timestamp, status_timestamp.
-- Added checks that verify that the function handler in an uploaded funtion is correctly constructed.
+- Added checks that verify that the function handler in an uploaded function is correctly constructed.
 
 ## [0.5.5] - 2020-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes are grouped as follows
 ## [0.5.6] - 2020-04-28
 
 ### Added
-- Added checks that verifies that the function handler in an uploaded funtions is correctly constructed.
+- Added checks that verify that the function handler in an uploaded funtion is correctly constructed.
 
 ## [0.5.5] - 2020-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [0.5.5] - 2020-04-27
+## [0.5.6] - 2020-04-28
 
 ### Added
 - Added checks that verifies that the function handler in an uploaded funtions is correctly constructed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.5.5] - 2020-04-27
+
+### Added
+- Added handler checks to functions to the functions API module.
+
 ## [0.5.5] - 2020-04-21
 
 ### Changed

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -80,7 +80,7 @@ class FunctionsAPI(APIClient):
         self._assert_exactly_one_of_folder_or_file_id_or_function_handle(folder, file_id, function_handle)
 
         if folder:
-            validate_handler_file(os.path.join(folder, HANDLER_FILE_NAME))
+            validate_handler_file(folder)
             file_id = self._zip_and_upload_folder(folder, name)
         elif function_handle:
             _validate_function_handle(function_handle)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -80,7 +80,7 @@ class FunctionsAPI(APIClient):
         self._assert_exactly_one_of_folder_or_file_id_or_function_handle(folder, file_id, function_handle)
 
         if folder:
-            validate_handler_file(folder)
+            validate_handler_folder(folder)
             file_id = self._zip_and_upload_folder(folder, name)
         elif function_handle:
             _validate_function_handle(function_handle)
@@ -288,9 +288,9 @@ class FunctionsAPI(APIClient):
             )
 
 
-def validate_handler_file(folder_with_handler_file):
-    sys.path.append(folder_with_handler_file)
-    if HANDLER_FILE_NAME not in os.listdir(folder_with_handler_file):
+def validate_function_folder(path):
+    sys.path.append(path)
+    if HANDLER_FILE_NAME not in os.listdir(path):
         raise TypeError(f"Function folder must contain a module named {HANDLER_FILE_NAME}.")
 
     import handler
@@ -299,7 +299,7 @@ def validate_handler_file(folder_with_handler_file):
         raise TypeError(f"{HANDLER_FILE_NAME} must contain a function named 'handle'.")
 
     _validate_function_handle(handler.handle)
-    sys.path.remove(folder_with_handler_file)
+    sys.path.remove(path)
 
 
 def _validate_function_handle(function_handle):

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -284,16 +284,16 @@ class FunctionsAPI(APIClient):
                 + " were given."
             )
 
-    @staticmethod
-    def validate_handler_file(target_directory):
-        sys.path.append(target_directory)
-        import handler
 
-        if "handle" not in handler.__dir__():
-            raise TypeError(f"'handler.py' must contain a function named 'handle'.")
+def validate_handler_file(target_directory):
+    sys.path.append(target_directory)
+    import handler
 
-        _validate_function_handle(handler.handle)
-        sys.path.remove(target_directory)
+    if "handle" not in handler.__dir__():
+        raise TypeError(f"'handler.py' must contain a function named 'handle'.")
+
+    _validate_function_handle(handler.handle)
+    sys.path.remove(target_directory)
 
 
 def _validate_function_handle(function_handle):

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -285,15 +285,15 @@ class FunctionsAPI(APIClient):
             )
 
 
-def validate_handler_file(target_directory):
-    sys.path.append(target_directory)
+def validate_handler_file(path_to_handler_file):
+    sys.path.append(path_to_handler_file)
     import handler
 
     if "handle" not in handler.__dir__():
         raise TypeError(f"'handler.py' must contain a function named 'handle'.")
 
     _validate_function_handle(handler.handle)
-    sys.path.remove(target_directory)
+    sys.path.remove(path_to_handler_file)
 
 
 def _validate_function_handle(function_handle):

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -80,7 +80,7 @@ class FunctionsAPI(APIClient):
         self._assert_exactly_one_of_folder_or_file_id_or_function_handle(folder, file_id, function_handle)
 
         if folder:
-            validate_handler_folder(folder)
+            validate_function_folder(folder)
             file_id = self._zip_and_upload_folder(folder, name)
         elif function_handle:
             _validate_function_handle(function_handle)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -288,15 +288,18 @@ class FunctionsAPI(APIClient):
             )
 
 
-def validate_handler_file(path_to_handler_file):
-    sys.path.append(path_to_handler_file)
+def validate_handler_file(folder_with_handler_file):
+    sys.path.append(folder_with_handler_file)
+    if HANDLER_FILE_NAME not in os.listdir(folder_with_handler_file):
+        raise TypeError(f"Function folder must contain a module named {HANDLER_FILE_NAME}.")
+
     import handler
 
     if "handle" not in handler.__dir__():
         raise TypeError(f"{HANDLER_FILE_NAME} must contain a function named 'handle'.")
 
     _validate_function_handle(handler.handle)
-    sys.path.remove(path_to_handler_file)
+    sys.path.remove(folder_with_handler_file)
 
 
 def _validate_function_handle(function_handle):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.5.5"
+version = "0.5.6"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/bad_function_code2/handler.py
+++ b/tests/tests_unit/test_api/bad_function_code2/handler.py
@@ -1,0 +1,2 @@
+def xyz(data):
+    return {"assetId": 1234}

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from cognite.experimental import CogniteClient
-from cognite.experimental._api.functions import validate_handler_file
+from cognite.experimental._api.functions import validate_function_folder
 from cognite.experimental.data_classes import (
     Function,
     FunctionCall,
@@ -164,12 +164,19 @@ def function_handle_illegal_argument():
     return handle
 
 
-def test_validate_handler_file():
-    folder = os.path.join(os.path.dirname(__file__), "function_code")
-    validate_handler_file(folder)
-
-
 class TestFunctionsAPI:
+    @pytest.mark.parametrize(
+        "function_folder, will_pass",
+        [("function_code", True), ("bad_function_code", False), ("bad_function_code2", False)],
+    )
+    def test_validate_folder(self, function_folder, will_pass):
+        folder = os.path.join(os.path.dirname(__file__), function_folder)
+        if will_pass:
+            validate_function_folder(folder)
+        else:
+            with pytest.raises(TypeError):
+                validate_function_folder(folder)
+
     def test_create_with_path(self, mock_functions_create_response):
         folder = os.path.join(os.path.dirname(__file__), "function_code")
         res = FUNCTIONS_API.create(name="myfunction", folder=folder)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from cognite.experimental import CogniteClient
+from cognite.experimental._api.functions import validate_handler_file
 from cognite.experimental.data_classes import (
     Function,
     FunctionCall,
@@ -161,6 +162,11 @@ def function_handle_illegal_argument():
         pass
 
     return handle
+
+
+def test_validate_handler_file():
+    folder = os.path.join(os.path.dirname(__file__), "function_code")
+    validate_handler_file(folder)
 
 
 class TestFunctionsAPI:


### PR DESCRIPTION
Add checks to the handler checking if the file module contains a function with the correct attributes, i.e. has a function named `handle` with the correct arguments.

```
from cognite.experimental._api.functions import validate_handler_file
validate_function_folder('/path/to/handler.py/')
```