### PR TITLE
Incorporate function id in function call and remove `_load` method overloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
-## Unreleased
+## [0.8.0]
+### Changed
+- Because the new function call response from the  Cognite functions api now returns functions id, the endpoint for getting logs of a call no longer needs the function_id.
 
 ### Fixed
 - Dosctring for `FunctionCallsAPI.list()` erroneously listed `external_id` as optional argument. This has been corrected to `function_external_id`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changes are grouped as follows
 - `Security` in case of vulnerabilities.
 
 
-## [0.8.0]
+## [0.7.3]
 ### Changed
 - Because the new function call response from the  Cognite functions api now returns functions id, the endpoint for getting logs of a call no longer needs the function_id.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes are grouped as follows
 
 ## [0.7.3]
 ### Changed
-- Because the new function call response from the  Cognite functions api now returns functions id, the endpoint for getting logs of a call no longer needs the function_id.
+- Because the new function call response from the  Cognite functions api now returns functions id, the endpoint for getting logs of a call has a simplified internal structure.
 
 ### Fixed
 - Dosctring for `FunctionCallsAPI.list()` erroneously listed `external_id` as optional argument. This has been corrected to `function_external_id`.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -364,8 +364,8 @@ class FunctionCallsAPI(APIClient):
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls"
-
-        return self._list(method="POST", resource_path=url)
+        res = self._get(url)
+        return FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -332,8 +332,6 @@ def _validate_function_handle(function_handle):
 
 
 class FunctionCallsAPI(APIClient):
-    _LIST_CLASS = FunctionCallList
-
     def list(self, function_id: Optional[int] = None, function_external_id: Optional[str] = None) -> FunctionCallList:
         """`List all calls associated with a specific function. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-function_name-calls>`_
 

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -235,7 +235,7 @@ class FunctionsAPI(APIClient):
         if data:
             body = {"data": data}
         res = self._post(url, json=body)
-        return FunctionCall._load(res.json(), function_id=id, cognite_client=self._cognite_client)
+        return FunctionCall._load(res.json(), cognite_client=self._cognite_client)
 
     def _zip_and_upload_folder(self, folder, name) -> int:
         # / is not allowed in file names
@@ -358,7 +358,7 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls"
         res = self._get(url)
-        return FunctionCallList._load(res.json()["items"], function_id=function_id, cognite_client=self._cognite_client)
+        return FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
@@ -394,7 +394,7 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls/{call_id}"
         res = self._get(url)
-        return FunctionCall._load(res.json(), function_id=function_id, cognite_client=self._cognite_client)
+        return FunctionCall._load(res.json(), cognite_client=self._cognite_client)
 
     def get_logs(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -327,6 +327,8 @@ def _validate_function_handle(function_handle):
 
 
 class FunctionCallsAPI(APIClient):
+    _LIST_CLASS = FunctionCallList
+
     def list(self, function_id: Optional[int] = None, function_external_id: Optional[str] = None) -> FunctionCallList:
         """`List all calls associated with a specific function. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-function_name-calls>`_
 
@@ -357,8 +359,8 @@ class FunctionCallsAPI(APIClient):
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls"
-        res = self._get(url)
-        return FunctionCallList._load(res.json()["items"], cognite_client=self._cognite_client)
+
+        return self._list(method="POST", resource_path=url)
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -110,6 +110,7 @@ class FunctionList(CogniteResourceList):
 
 
 class FunctionCall(CogniteResource):
+
     """A representation of a Cognite Function call.
 
     Args:

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -139,30 +139,16 @@ class FunctionCall(CogniteResource):
         self.response = response
         self.status = status
         self.error = error
-        self._function_id = function_id
+        self.function_id = function_id
         self._cognite_client = cognite_client
 
     def get_logs(self):
-        return self._cognite_client.functions.calls.get_logs(call_id=self.id, function_id=self._function_id)
-
-    @classmethod
-    def _load(cls, resource: Union[Dict, str], function_id: int = None, cognite_client=None):
-        instance = super()._load(resource, cognite_client=cognite_client)
-        if function_id:
-            instance._function_id = function_id
-        return instance
+        return self._cognite_client.functions.calls.get_logs(call_id=self.id, function_id=self.function_id)
 
 
 class FunctionCallList(CogniteResourceList):
     _RESOURCE = FunctionCall
     _ASSERT_CLASSES = False
-
-    @classmethod
-    def _load(cls, resource: Union[List, str], function_id: int, cognite_client=None):
-        instance = super()._load(resource, cognite_client=cognite_client)
-        for obj in instance:
-            obj._function_id = function_id
-        return instance
 
 
 class FunctionCallLogEntry(CogniteResource):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.7.2"
+version = "0.8.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.8.0"
+version = "0.7.3"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -297,9 +297,9 @@ class TestFunctionsAPI:
 @pytest.fixture
 def mock_function_calls_list_response(rsps):
     response_body = {"items": [BASE_CALL.copy()]}
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
     rsps.assert_all_requests_are_fired = False
-    rsps.add(rsps.GET, url, status=200, json=response_body)
+    rsps.add(rsps.POST, url, status=200, json=response_body)
 
     yield rsps
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -21,11 +21,12 @@ FUNCTION_CALLS_API = FUNCTIONS_API.calls
 FUNCTION_SCHEDULES_API = FUNCTIONS_API.schedules
 FILES_API = COGNITE_CLIENT.files
 
+FUNCTION_ID = 1234
 
 EXAMPLE_FUNCTION = {
-    "id": 1234,
+    "id": FUNCTION_ID,
     "name": "myfunction",
-    "externalId": "func-no-1234",
+    "externalId": f"func-no-{FUNCTION_ID}",
     "description": "my fabulous function",
     "owner": "ola.normann@cognite.com",
     "status": "Ready",
@@ -60,7 +61,7 @@ def mock_functions_retrieve_response(rsps):
 def mock_functions_create_response(rsps):
     files_response_body = {
         "name": "myfunction",
-        "id": 1234,
+        "id": FUNCTION_ID,
         "uploaded": True,
         "createdTime": 1585662507939,
         "lastUpdatedTime": 1585662507939,
@@ -87,7 +88,13 @@ def mock_functions_delete_response(rsps):
     yield rsps
 
 
-BASE_CALL = {"id": 5678, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Completed"}
+BASE_CALL = {
+    "id": 5678,
+    "startTime": 1585925306822,
+    "endTime": 1585925310822,
+    "status": "Completed",
+    "functionId": FUNCTION_ID,
+}
 
 
 @pytest.fixture
@@ -96,8 +103,8 @@ def mock_functions_call_completed_response(rsps):
     response_body_sync = BASE_CALL.copy()
     response_body_sync["response"] = "Hello World!"
 
-    url_sync = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
-    url_async = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/async_call"
+    url_sync = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
+    url_async = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/async_call"
     rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.POST, url_sync, status=201, json=response_body_sync)
     rsps.add(rsps.POST, url_async, status=201, json=response_body_async)
@@ -110,7 +117,7 @@ def mock_functions_call_by_external_id(mock_functions_retrieve_response):
     response_body = BASE_CALL.copy()
     response_body["response"] = "Hello World!"
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps = mock_functions_retrieve_response
     rsps.add(rsps.POST, url, status=201, json=response_body)
 
@@ -123,7 +130,7 @@ def mock_functions_call_failed_response(rsps):
     response_body["status"] = "Failed"
     response_body["error"] = ({"message": "some message", "trace": "some stack trace"},)
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=response_body)
 
     yield rsps
@@ -134,7 +141,7 @@ def mock_functions_call_timeout_response(rsps):
     response_body = BASE_CALL.copy()
     response_body["status"] = "Timeout"
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=response_body)
 
     yield rsps
@@ -262,27 +269,27 @@ class TestFunctionsAPI:
         assert mock_functions_retrieve_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     def test_function_call(self, mock_functions_call_completed_response):
-        res = FUNCTIONS_API.call(id=1234)
+        res = FUNCTIONS_API.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_function_async_call(self, mock_functions_call_completed_response):
-        res = FUNCTIONS_API.call(id=1234, asynchronous=True)
+        res = FUNCTIONS_API.call(id=FUNCTION_ID, asynchronous=True)
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_completed_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_function_call_by_external_id(self, mock_functions_call_by_external_id):
-        res = FUNCTIONS_API.call(external_id="func-no-1234")
+        res = FUNCTIONS_API.call(external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_by_external_id.calls[1].response.json() == res.dump(camel_case=True)
 
     def test_function_call_failed(self, mock_functions_call_failed_response):
-        res = FUNCTIONS_API.call(id=1234)
+        res = FUNCTIONS_API.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_failed_response.calls[0].response.json() == res.dump(camel_case=True)
 
     def test_function_call_timout(self, mock_functions_call_timeout_response):
-        res = FUNCTIONS_API.call(id=1234)
+        res = FUNCTIONS_API.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
         assert mock_functions_call_timeout_response.calls[0].response.json() == res.dump(camel_case=True)
 
@@ -290,7 +297,7 @@ class TestFunctionsAPI:
 @pytest.fixture
 def mock_function_calls_list_response(rsps):
     response_body = {"items": [BASE_CALL.copy()]}
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/calls"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls"
     rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.GET, url, status=200, json=response_body)
 
@@ -300,7 +307,7 @@ def mock_function_calls_list_response(rsps):
 @pytest.fixture
 def mock_function_calls_retrieve_response(rsps):
     response_body = BASE_CALL.copy()
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/calls/5678"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/5678"
     rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.GET, url, status=200, json=response_body)
 
@@ -315,7 +322,7 @@ def mock_function_call_logs_response(rsps):
             {"timestamp": 1585925310822, "message": "message 2"},
         ]
     }
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/calls/5678/logs"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/5678/logs"
     rsps.assert_all_requests_are_fired = False
     rsps.add(rsps.GET, url, status=200, json=response_body)
 
@@ -411,48 +418,48 @@ class TestFunctionSchedulesAPI:
 
 class TestFunctionCallsAPI:
     def test_list_calls_by_function_id(self, mock_function_calls_list_response):
-        res = FUNCTION_CALLS_API.list(function_id=1234)
+        res = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCallList)
         assert mock_function_calls_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_list_calls_by_function_external_id(self, mock_function_calls_list_response):
-        res = FUNCTION_CALLS_API.list(function_external_id="func-no-1234")
+        res = FUNCTION_CALLS_API.list(function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCallList)
         assert mock_function_calls_list_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
 
     def test_retrieve_call_by_function_id(self, mock_function_calls_retrieve_response):
-        res = FUNCTION_CALLS_API.retrieve(call_id=5678, function_id=1234)
+        res = FUNCTION_CALLS_API.retrieve(call_id=5678, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
         assert mock_function_calls_retrieve_response.calls[0].response.json() == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_retrieve_call_by_function_external_id(self, mock_function_calls_retrieve_response):
-        res = FUNCTION_CALLS_API.retrieve(call_id=5678, function_external_id="func-no-1234")
+        res = FUNCTION_CALLS_API.retrieve(call_id=5678, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCall)
         assert mock_function_calls_retrieve_response.calls[1].response.json() == res.dump(camel_case=True)
 
     def test_function_call_logs_by_function_id(self, mock_function_call_logs_response):
-        res = FUNCTION_CALLS_API.get_logs(call_id=5678, function_id=1234)
+        res = FUNCTION_CALLS_API.get_logs(call_id=5678, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCallLog)
         assert mock_function_call_logs_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_function_call_logs_by_function_external_id(self, mock_function_call_logs_response):
-        res = FUNCTION_CALLS_API.get_logs(call_id=5678, function_external_id="func-no-1234")
+        res = FUNCTION_CALLS_API.get_logs(call_id=5678, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCallLog)
         assert mock_function_call_logs_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_function_calls_retrieve_response")
     def test_get_logs_on_retrieved_call_object(self, mock_function_call_logs_response):
-        call = FUNCTION_CALLS_API.retrieve(call_id=5678, function_id=1234)
+        call = FUNCTION_CALLS_API.retrieve(call_id=5678, function_id=FUNCTION_ID)
         logs = call.get_logs()
         assert isinstance(logs, FunctionCallLog)
         assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_function_calls_list_response")
     def test_get_logs_on_listed_call_object(self, mock_function_call_logs_response):
-        calls = FUNCTION_CALLS_API.list(function_id=1234)
+        calls = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID)
         call = calls[0]
         logs = call.get_logs()
         assert isinstance(logs, FunctionCallLog)
@@ -460,7 +467,7 @@ class TestFunctionCallsAPI:
 
     @pytest.mark.usefixtures("mock_functions_call_completed_response")
     def test_get_logs_on_created_call_object(self, mock_function_call_logs_response):
-        call = FUNCTIONS_API.call(id=1234)
+        call = FUNCTIONS_API.call(id=FUNCTION_ID)
         logs = call.get_logs()
         assert isinstance(logs, FunctionCallLog)
         assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -306,8 +306,8 @@ class TestFunctionsAPI:
 @pytest.fixture
 def mock_function_calls_list_response(rsps):
     response_body = {"items": [CALL_COMPLETED]}
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
-    rsps.add(rsps.POST, url, status=200, json=response_body)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls"
+    rsps.add(rsps.GET, url, status=200, json=response_body)
 
     yield rsps
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -121,7 +121,7 @@ def mock_functions_delete_response(rsps):
 
 @pytest.fixture
 def mock_functions_call_responses(rsps):
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/1234/call"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=CALL_RUNNING)
 
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/5678"

--- a/tests/tests_unit/test_data_classes/test_functions.py
+++ b/tests/tests_unit/test_data_classes/test_functions.py
@@ -1,21 +1,23 @@
-import pytest
-
 from cognite.experimental.data_classes import FunctionCall, FunctionCallList
 
-CALL_RESPONSE = {"id": 5678, "startTime": 1585925306822, "endTime": 1585925310822, "status": "Completed"}
+CALL_RESPONSE = {
+    "id": 5678,
+    "startTime": 1585925306822,
+    "endTime": 1585925310822,
+    "status": "Completed",
+    "functionId": 1234,
+}
 
 
 class TestFunctionCall:
     def test_load(self):
-        function_id = 1234
-        call = FunctionCall._load(CALL_RESPONSE, function_id=function_id)
-        assert function_id == call._function_id
+
+        call = FunctionCall._load(CALL_RESPONSE)
         assert CALL_RESPONSE == call.dump(camel_case=True)
 
 
 class TestFunctionCallList:
     def test_load(self):
-        function_id = 1234
-        calls = FunctionCallList._load([CALL_RESPONSE], function_id=function_id)
-        assert function_id == calls[0]._function_id
+
+        calls = FunctionCallList._load([CALL_RESPONSE])
         assert [CALL_RESPONSE] == calls.dump(camel_case=True)


### PR DESCRIPTION
# Incorporate function id in function calls
When the function id is present in the call, we no longer need to overload the `_load` method which enables us to use the `_list` endpoint in the APIClient in the SDK. 