### PR TITLE
[CDF-8433] Entity matcher name, description and external-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.15.1] - 2020-08-13
+### Added
+- Add name, description and external-id parameters to fit entity matcher.
+
 ## [0.15.1] - 2020-08-10
 ### Added
 - Add model info for entity matcher models (classifier, feature_type, model_to, keys_from_to) to the output of retrieve.

--- a/cognite/experimental/_api/entity_matching.py
+++ b/cognite/experimental/_api/entity_matching.py
@@ -18,6 +18,9 @@ class EntityMatchingAPI(ContextModelAPI):
         feature_type: str = None,
         classifier: str = None,
         complete_missing: bool = False,
+        name: str = None,
+        description: str = None,
+        external_id: str = None,
     ) -> EntityMatchingModel:
         """Fit entity matching model with machine learning methods.
 
@@ -28,7 +31,10 @@ class EntityMatchingAPI(ContextModelAPI):
             keys_from_to: List of (from,to) keys to use in matching. Default in the API is [('name','name')]
             feature_type (str): feature type that defines the combination of features used, see API docs for details.
             classifier (str): classifier used in training. Currently undocumented in API.
-            complete_missing (bool): whether missing data in keyFrom or keyTo should return error or be filled in with an empty string. Currently undocumented in API
+            complete_missing (bool): whether missing data in keyFrom or keyTo should return error or be filled in with an empty string. Currently undocumented in API.
+            name (str): Optional user-defined name of model.
+            description (str): Optional user-defined description of model.
+            external_id [str): Optional external id. Must be unique within the project.
         Returns:
             EntityMatchingModel: Resulting queued model."""
         if keys_from_to:
@@ -44,6 +50,9 @@ class EntityMatchingAPI(ContextModelAPI):
             feature_type=feature_type,
             classifier=classifier,
             complete_missing=complete_missing,
+            name=name,
+            description=description,
+            external_id=external_id,
         )
 
     def fit_ml(
@@ -55,6 +64,9 @@ class EntityMatchingAPI(ContextModelAPI):
         feature_type: str = None,
         classifier: str = None,
         complete_missing: bool = False,
+        name: str = None,
+        description: str = None,
+        external_id: str = None,
     ) -> EntityMatchingModel:
         """Duplicate of fit will eventually be removed"""
         if keys_from_to:
@@ -70,6 +82,9 @@ class EntityMatchingAPI(ContextModelAPI):
             feature_type=feature_type,
             classifier=classifier,
             complete_missing=complete_missing,
+            name=name,
+            description=description,
+            external_id=external_id,
         )
 
     def create_rules(self, matches: List[Dict]) -> ContextualizationJob:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.15.1"
+version = "0.15.2"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_integration/test_contextualization/test_entity_matching.py
+++ b/tests/tests_integration/test_contextualization/test_entity_matching.py
@@ -103,6 +103,9 @@ class TestEntityMatchingIntegration:
             keys_from_to=[("name", "missing")],
             complete_missing=True,
             classifier="LogisticRegression",
+            name="my_bigram_logReg_model",
+            description="My model with bigram features",
+            external_id="bigram_logReg_01",
         )
         assert isinstance(model, EntityMatchingModel)
         assert "Queued" == model.status

--- a/tests/tests_integration/test_contextualization/test_entity_matching.py
+++ b/tests/tests_integration/test_contextualization/test_entity_matching.py
@@ -105,7 +105,6 @@ class TestEntityMatchingIntegration:
             classifier="LogisticRegression",
             name="my_bigram_logReg_model",
             description="My model with bigram features",
-            external_id="bigram_logReg_01",
         )
         assert isinstance(model, EntityMatchingModel)
         assert "Queued" == model.status


### PR DESCRIPTION
This PR adds name, description and external-id parameter to fit for entity matcher.

It relates to https://github.com/cognitedata/context-api/pull/770