### PR TITLE
Add py.typed file so that mypy knows that package is typed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.17.0"
+version = "0.18.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
We (unstructured search) painfully discovered that mypy doesn't know types of an installed package, even when it has been typed.

This change is apparently needed, and is per [this accepted Python Enhancement Proposal](https://www.python.org/dev/peps/pep-0561/). From [mypy docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#making-pep-561-compatible-packages):

> If you would like to publish a library package to a package repository (e.g. PyPI) for either internal or external use in type checking, packages that supply type information via type comments or annotations in the code should put a py.typed file in their package directory.

See also [this PR for the cognite-auth package](https://github.com/cognitedata/python-auth/pull/58) and [this PR in the main sdk](https://github.com/cognitedata/cognite-sdk-python/pull/727).

I updated the minor version.