### PR TITLE
Relationship: Add high-level query feature for Relationship

### DIFF
--- a/cognite/experimental/__init__.py
+++ b/cognite/experimental/__init__.py
@@ -1,1 +1,2 @@
 from cognite.experimental._client import CogniteClient
+from cognite.experimental._relationships_query import RelationshipsQuery

--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -4,7 +4,7 @@ from typing import Callable, Dict, Optional, Union
 from cognite.client._api.datapoints import DatapointsAPI
 from cognite.client._api.files import FilesAPI
 from cognite.client._api_client import APIClient
-from cognite.client._cognite_client import CogniteClient as Client
+from cognite.client.beta import CogniteClient as Client
 from cognite.experimental._api.assets import ExperimentalAssetsAPI
 from cognite.experimental._api.document_parsing import DocumentParsingAPI
 from cognite.experimental._api.entity_extraction import EntityExtractionAPI

--- a/cognite/experimental/_relationships_query.py
+++ b/cognite/experimental/_relationships_query.py
@@ -1,0 +1,128 @@
+from collections import defaultdict, namedtuple
+from typing import Any, Dict, Generator, List, Union
+
+from cognite.client import utils
+from cognite.client.beta import CogniteClient
+from cognite.client.data_classes import Asset, Event, Relationship, Sequence, TimeSeries
+from cognite.client.data_classes._base import CogniteResource
+from cognite.client.data_classes.files import FileMetadata
+from cognite.client.data_classes.labels import LabelFilter
+
+ResourceRef = namedtuple("ResourceRef", ["type", "external_id"])
+Resource = Union[Asset, TimeSeries, Event, FileMetadata, Sequence]
+
+
+class ResourceFilterBase:
+    def is_inside(self, resource: Resource) -> bool:
+        return False
+
+
+class ResourceFilter(ResourceFilterBase):
+    def __init__(self, labels):
+        self.labels = labels
+
+    def is_inside(self, resource: Resource):
+        if resource.labels is not None:
+            labels_decoded = [label["externalId"] for label in resource.labels]
+            return any(label in self.labels for label in labels_decoded)
+        else:
+            return False
+
+
+class ResourceFilterAll(ResourceFilterBase):
+    def is_inside(self, resource: Resource):
+        return True
+
+
+class RelationshipWithResource(CogniteResource):
+    def __init__(self, relationship: Relationship, source_resource: Resource, target_resource: Resource):
+        self.relationship = relationship
+        self.source_resource = source_resource
+        self.target_resource = target_resource
+
+
+class Fetcher:
+    def __init__(self, has_ignore_unknown_ids, retrieve_multiple):
+        self.has_ignore_unknown_ids = has_ignore_unknown_ids
+        self.retrieve_multiple = retrieve_multiple
+
+    def retrieve_multiple(self, external_ids: List[str]):
+        if self.has_ignore_unknown_ids:
+            return self.retrieve_multiple(external_ids=external_ids, ignore_unknown_ids=True)
+        else:
+            return self.retrieve_multiple(external_ids=external_ids)
+
+
+class RelationshipsQuery:
+    def __init__(self, client: CogniteClient):
+        self.client = client
+        self.fetchers = {
+            "asset": Fetcher(True, self.client.assets.retrieve_multiple),
+            "timeSeries": Fetcher(True, self.client.time_series.retrieve_multiple),
+            "file": Fetcher(False, self.client.files.retrieve_multiple),
+            "event": Fetcher(True, self.client.events.retrieve_multiple),
+            "sequence": Fetcher(False, self.client.sequences.retrieve_multiple),
+        }
+
+    def query(
+        self,
+        sources: List[Resource] = None,
+        source_types: List[str] = None,
+        sources_filter: ResourceFilterBase = None,
+        targets: List[Resource] = None,
+        target_types: List[str] = None,
+        targets_filter: ResourceFilterBase = None,
+        data_set_ids: List[Dict[str, Any]] = None,
+        labels: LabelFilter = None,
+        limit: int = None,
+    ) -> Generator[RelationshipWithResource, None, None]:
+        sources_filter = sources_filter if sources_filter is not None else ResourceFilterAll()
+        targets_filter = targets_filter if targets_filter is not None else ResourceFilterAll()
+
+        relations = self.client.relationships.list(
+            source_external_ids=set([res.external_id for res in sources]) if sources is not None else None,
+            source_types=source_types,
+            target_external_ids=set([res.external_id for res in targets]) if targets is not None else None,
+            target_types=target_types,
+            labels=labels,
+            data_set_ids=data_set_ids,
+            limit=limit,
+        )
+
+        resource_refs = set(
+            [ResourceRef(type=rel.source_type, external_id=rel.source_external_id) for rel in relations]
+            + [ResourceRef(type=rel.target_type, external_id=rel.target_external_id) for rel in relations]
+        )
+
+        resources_by_type = defaultdict(list)
+        for res in resource_refs:
+            resources_by_type[res.type].append(res.external_id)
+
+        def fetch_per_type(type, external_ids):
+            resources = self.fetchers[type].retrieve_multiple(external_ids=external_ids)
+            return [(type, res) for res in resources]
+
+        tasks_summary = utils._concurrency.execute_tasks_concurrently(
+            fetch_per_type, [(type, external_ids) for type, external_ids in resources_by_type.items()], max_workers=5
+        )
+
+        if tasks_summary.exceptions:
+            raise tasks_summary.exceptions[0]
+
+        resources_by_ext_id = {}
+        for item in tasks_summary.joined_results():
+            type, res = item
+            resources_by_ext_id[ResourceRef(type, res.external_id)] = res
+
+        for rel in relations:
+            source_ref = ResourceRef(rel.source_type, rel.source_external_id)
+            source_resource = resources_by_ext_id.get(source_ref)
+            target_ref = ResourceRef(rel.target_type, rel.target_external_id)
+            target_resource = resources_by_ext_id.get(target_ref)
+            if (
+                source_resource is not None
+                and sources_filter.is_inside(source_resource)
+                and target_resource is not None
+                and targets_filter.is_inside(target_resource)
+            ):
+                yield RelationshipWithResource(rel, source_resource, target_resource)

--- a/poetry.lock
+++ b/poetry.lock
@@ -131,7 +131,7 @@ description = "Client library for Cognite Data Fusion (CDF)"
 name = "cognite-sdk"
 optional = false
 python-versions = ">=3.5"
-version = "2.4.3"
+version = "2.5.0"
 
 [package.dependencies]
 pandas = "*"
@@ -957,6 +957,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 
 [metadata]
 content-hash = "54ce0b6ce986774900a0cc838e6f45434a5509169e8eb1292bbb98379c5812c7"
+lock-version = "1.0"
 python-versions = "^3.6.1"
 
 [metadata.files]
@@ -993,37 +994,37 @@ certifi = [
     {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
 ]
 cffi = [
-    {file = "cffi-1.14.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:485d029815771b9fe4fa7e1c304352fe57df6939afe835dfd0182c7c13d5e92e"},
+    {file = "cffi-1.14.3-2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3eeeb0405fd145e714f7633a5173318bd88d8bbfc3dd0a5751f8c4f70ae629bc"},
+    {file = "cffi-1.14.3-2-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:cb763ceceae04803adcc4e2d80d611ef201c73da32d8f2722e9d0ab0c7f10768"},
+    {file = "cffi-1.14.3-2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f60519595eaca110f248e5017363d751b12782a6f2bd6a7041cba275215f5d"},
+    {file = "cffi-1.14.3-2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c53af463f4a40de78c58b8b2710ade243c81cbca641e34debf3396a9640d6ec1"},
+    {file = "cffi-1.14.3-2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:33c6cdc071ba5cd6d96769c8969a0531be2d08c2628a0143a10a7dcffa9719ca"},
+    {file = "cffi-1.14.3-2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c11579638288e53fc94ad60022ff1b67865363e730ee41ad5e6f0a17188b327a"},
     {file = "cffi-1.14.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c"},
     {file = "cffi-1.14.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730"},
     {file = "cffi-1.14.3-cp27-cp27m-win32.whl", hash = "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d"},
     {file = "cffi-1.14.3-cp27-cp27m-win_amd64.whl", hash = "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05"},
     {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b"},
     {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171"},
-    {file = "cffi-1.14.3-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:52bf29af05344c95136df71716bb60508bbd217691697b4307dcae681612db9f"},
     {file = "cffi-1.14.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f"},
     {file = "cffi-1.14.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4"},
     {file = "cffi-1.14.3-cp35-cp35m-win32.whl", hash = "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d"},
     {file = "cffi-1.14.3-cp35-cp35m-win_amd64.whl", hash = "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d"},
-    {file = "cffi-1.14.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c687778dda01832555e0af205375d649fa47afeaeeb50a201711f9a9573323b8"},
     {file = "cffi-1.14.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3"},
     {file = "cffi-1.14.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808"},
     {file = "cffi-1.14.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:23e5d2040367322824605bc29ae8ee9175200b92cb5483ac7d466927a9b3d537"},
     {file = "cffi-1.14.3-cp36-cp36m-win32.whl", hash = "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0"},
     {file = "cffi-1.14.3-cp36-cp36m-win_amd64.whl", hash = "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e"},
-    {file = "cffi-1.14.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:03d3d238cc6c636a01cf55b9b2e1b6531a7f2f4103fabb5a744231582e68ecc7"},
     {file = "cffi-1.14.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1"},
     {file = "cffi-1.14.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579"},
     {file = "cffi-1.14.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f4eae045e6ab2bb54ca279733fe4eb85f1effda392666308250714e01907f394"},
     {file = "cffi-1.14.3-cp37-cp37m-win32.whl", hash = "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc"},
     {file = "cffi-1.14.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869"},
-    {file = "cffi-1.14.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c2a33558fdbee3df370399fe1712d72464ce39c66436270f3664c03f94971aff"},
     {file = "cffi-1.14.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e"},
     {file = "cffi-1.14.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828"},
     {file = "cffi-1.14.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f0f1e499e4000c4c347a124fa6a27d37608ced4fe9f7d45070563b7c4c370c9"},
     {file = "cffi-1.14.3-cp38-cp38-win32.whl", hash = "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522"},
     {file = "cffi-1.14.3-cp38-cp38-win_amd64.whl", hash = "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15"},
-    {file = "cffi-1.14.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5d9a7dc7cf8b1101af2602fe238911bcc1ac36d239e0a577831f5dac993856e9"},
     {file = "cffi-1.14.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d"},
     {file = "cffi-1.14.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c"},
     {file = "cffi-1.14.3-cp39-cp39-win32.whl", hash = "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b"},
@@ -1043,8 +1044,8 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 cognite-sdk = [
-    {file = "cognite-sdk-2.4.3.tar.gz", hash = "sha256:a34bae547088d22cf7d7b8a8bd04c6ed25c91097b2232957da0f45b495192c5a"},
-    {file = "cognite_sdk-2.4.3-py3-none-any.whl", hash = "sha256:c9029138c0dc03d84fb82fddd8572c065a0b79ffd2a75bc112706f7c6b990c99"},
+    {file = "cognite-sdk-2.5.0.tar.gz", hash = "sha256:4f11c97c91f753c2661c0f09b2a80523468a24e03439e4741e818f904e16710e"},
+    {file = "cognite_sdk-2.5.0-py3-none-any.whl", hash = "sha256:d15f30bacce32c55adb345d5d3728dd335eaacc441de9f082b7ffc5d7f1a2547"},
 ]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},

--- a/tests/tests_integration/test_relationships_query.py
+++ b/tests/tests_integration/test_relationships_query.py
@@ -1,0 +1,140 @@
+import uuid
+from collections import namedtuple
+
+import pytest
+
+from cognite.client.beta import CogniteClient
+from cognite.client.data_classes import (
+    Asset,
+    DataSet,
+    Event,
+    FileMetadata,
+    Label,
+    LabelDefinition,
+    Relationship,
+    Sequence,
+    TimeSeries,
+)
+from cognite.experimental import RelationshipsQuery
+
+COGNITE_CLIENT = CogniteClient()
+API_REL = COGNITE_CLIENT.relationships
+REL_QUERY_ENGINE = RelationshipsQuery(COGNITE_CLIENT)
+
+
+@pytest.fixture
+def new_assets():
+    resources = [Asset(name="any", external_id=uuid.uuid4().hex[0:20]) for _ in range(2)]
+    COGNITE_CLIENT.assets.create(resources)
+    yield resources
+    COGNITE_CLIENT.assets.delete(external_id=[res.external_id for res in resources])
+
+
+@pytest.fixture
+def new_time_series():
+    resources = [TimeSeries(name="any", external_id=uuid.uuid4().hex[0:20]) for _ in range(2)]
+    COGNITE_CLIENT.time_series.create(resources)
+    yield resources
+    COGNITE_CLIENT.time_series.delete(external_id=[res.external_id for res in resources])
+
+
+@pytest.fixture
+def new_files():
+    resources = [FileMetadata(name="any", external_id=uuid.uuid4().hex[0:20]) for _ in range(2)]
+    for res in resources:
+        COGNITE_CLIENT.files.create(res)
+    yield resources
+    COGNITE_CLIENT.files.delete(external_id=[res.external_id for res in resources])
+
+
+@pytest.fixture
+def new_sequence():
+    resources = [
+        Sequence(name="any", columns=[{"external_id": "foo"}], external_id=uuid.uuid4().hex[0:20]) for _ in range(2)
+    ]
+    COGNITE_CLIENT.sequences.create(resources)
+    yield resources
+    COGNITE_CLIENT.sequences.delete(external_id=[res.external_id for res in resources])
+
+
+@pytest.fixture
+def new_events():
+    resources = [Event(type="any", external_id=uuid.uuid4().hex[0:20]) for _ in range(2)]
+    COGNITE_CLIENT.events.create(resources)
+    yield resources
+    COGNITE_CLIENT.events.delete(external_id=[res.external_id for res in resources])
+
+
+@pytest.fixture
+def new_label():
+    external_id = uuid.uuid4().hex[0:20]
+    tp = COGNITE_CLIENT.labels.create(LabelDefinition(external_id=external_id, name="mandatory"))
+    assert isinstance(tp, LabelDefinition)
+    yield tp
+    COGNITE_CLIENT.labels.delete(external_id=tp.external_id)
+
+
+@pytest.fixture
+def new_data_set():
+    external_id = uuid.uuid4().hex[0:20]
+    d = COGNITE_CLIENT.data_sets.create(DataSet(external_id=external_id, name="relationships-query"))
+    yield d.id
+    # There are no delete endpoint for data sets
+
+
+AllResources = namedtuple("AllResources", ["assets", "timeSeries", "events", "files", "sequences"])
+
+
+@pytest.fixture
+def new_relationships(new_label, new_data_set, new_assets, new_events, new_time_series, new_files, new_sequence):
+    label_ext_id = new_label.external_id
+
+    def gen_id():
+        return uuid.uuid4().hex[0:20]
+
+    def create_relationship(type, ext_id):
+        return Relationship(
+            external_id=gen_id(),
+            source_type="asset",
+            source_external_id=new_assets[0].external_id,
+            target_type=type,
+            target_external_id=ext_id,
+            data_set_id=new_data_set,
+            labels=[Label(label_ext_id)],
+        )
+
+    relationshipList = [create_relationship("asset", new_assets[1].external_id)]
+
+    for res in new_events:
+        relationshipList.append(create_relationship("event", res.external_id))
+
+    for res in new_time_series:
+        relationshipList.append(create_relationship("timeSeries", res.external_id))
+
+    for res in new_files:
+        relationshipList.append(create_relationship("file", res.external_id))
+
+    for res in new_sequence:
+        relationshipList.append(create_relationship("sequence", res.external_id))
+
+    relationships = API_REL.create(relationshipList)
+    yield relationships, new_data_set, AllResources(new_assets, new_time_series, new_events, new_files, new_sequence)
+    API_REL.delete(external_id=[ext_ids["external_id"] for ext_ids in relationships.dump()])
+
+
+class TestRelationshipsQuery:
+    def test_all(self, new_relationships):
+        _, data_set_id, resources = new_relationships
+        data_set_id
+        query_result = list(REL_QUERY_ENGINE.query(data_set_ids=[{"id": data_set_id}]))
+        assert len(query_result) > 0
+        for rel in query_result:
+            assert rel.source_resource.external_id == resources.assets[0].external_id
+            if rel.relationship.target_type == "timeSeries":
+                assert rel.target_resource.external_id in [res.external_id for res in resources.timeSeries]
+            if rel.relationship.target_type == "event":
+                assert rel.target_resource.external_id in [res.external_id for res in resources.events]
+            if rel.relationship.target_type == "file":
+                assert rel.target_resource.external_id in [res.external_id for res in resources.files]
+            if rel.relationship.target_type == "sequence":
+                assert rel.target_resource.external_id in [res.external_id for res in resources.sequences]


### PR DESCRIPTION
Add a high-level relationship query resolver, to make it easier to traverse relationships.
It also supports filtering by label on the resolved resources, to allow saying match all relationships where "Asset has label Pump" for example.