### PR TITLE
[MLOPS-618] Changed the `FunctionCallsApi.retrieve`-method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [0.35] - 2012-12-14
+## [0.36] - 2020-01-05
+## Changed
+- The `FunctionCallAPI.retrieve` method now utilizes `retrieve_multiple` in the backend.
+
+## [0.35] - 2020-12-14
 ## Added
 - Added IntegrationsAPI and IntegrationRunsAPI
 
-## [0.34] - 2012-12-08
+## [0.34] - 2020-12-08
 ## Added
 - Added relationships_label and use_existing_matches to pipelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changes are grouped as follows
 - Added IntegrationsAPI and IntegrationRunsAPI
 
 ## [0.34] - 2020-12-08
-## Added
+### Added
 - Added relationships_label and use_existing_matches to pipelines
 
 ## [0.33.0] - 2020-12-02

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -439,7 +439,7 @@ class FunctionCallsAPI(APIClient):
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
     ) -> Optional[FunctionCall]:
-        """`Retrieve a single function call by id. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-function_name-calls-call_id>`_
+        """`Retrieve a single function call by id. <https://docs.cognite.com/api/playground/#operation/byidsFunctionCalls>`_
 
         Args:
             call_id (int): ID of the call.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -438,8 +438,8 @@ class FunctionCallsAPI(APIClient):
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
-    ) -> FunctionCall:
-        """`Retrieve call by id. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-function_name-calls-call_id>`_
+    ) -> Optional[FunctionCall]:
+        """`Retrieve a single function call by id. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-function_name-calls-call_id>`_
 
         Args:
             call_id (int): ID of the call.
@@ -447,11 +447,11 @@ class FunctionCallsAPI(APIClient):
             function_external_id (str, optional): External ID of the function on which the call was made.
 
         Returns:
-            FunctionCall: Function call.
+            Optional[FunctionCall]: Requested function call.
 
         Examples:
 
-            Retrieve function call by id::
+            Retrieve single function call by id::
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -387,6 +387,8 @@ def _validate_function_handle(function_handle):
 
 
 class FunctionCallsAPI(APIClient):
+    _LIST_CLASS = FunctionCallList
+
     def list(
         self,
         function_id: Optional[int] = None,
@@ -466,9 +468,8 @@ class FunctionCallsAPI(APIClient):
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
-        url = f"/functions/{function_id}/calls/{call_id}"
-        res = self._get(url)
-        return FunctionCall._load(res.json(), cognite_client=self._cognite_client)
+        resource_path = f"/functions/{function_id}/calls"
+        return self._retrieve_multiple(wrap_ids=True, resource_path=resource_path, ids=call_id)
 
     def get_response(self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None):
         """Retrieve the response from a function call.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.35.1"
+version = "0.36.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -170,8 +170,8 @@ def mock_functions_call_by_external_id_responses(mock_functions_retrieve_respons
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=CALL_RUNNING)
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/{CALL_ID}"
-    rsps.add(rsps.GET, url, status=200, json=CALL_COMPLETED)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/byids"
+    rsps.add(rsps.POST, url, status=200, json={"items": [CALL_COMPLETED]})
 
     yield rsps
 
@@ -367,7 +367,9 @@ class TestFunctionsAPI:
         res = FUNCTIONS_API.call(external_id=f"func-no-{FUNCTION_ID}")
 
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_by_external_id_responses.calls[2].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_by_external_id_responses.calls[2].response.json()["items"][0] == res.dump(
+            camel_case=True
+        )
 
     def test_function_call_failed(self, mock_functions_call_failed_response):
         res = FUNCTIONS_API.call(id=FUNCTION_ID)
@@ -383,8 +385,8 @@ class TestFunctionsAPI:
 @pytest.fixture
 def mock_function_calls_retrieve_response(rsps):
     response_body = CALL_COMPLETED
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/{CALL_ID}"
-    rsps.add(rsps.GET, url, status=200, json=response_body)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/byids"
+    rsps.add(rsps.POST, url, status=200, json={"items": [response_body]})
 
     yield rsps
 
@@ -549,13 +551,13 @@ class TestFunctionCallsAPI:
     def test_retrieve_call_by_function_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_function_calls_retrieve_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_function_calls_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_retrieve_call_by_function_external_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCall)
-        assert mock_function_calls_retrieve_response.calls[1].response.json() == res.dump(camel_case=True)
+        assert mock_function_calls_retrieve_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
     def test_function_call_logs_by_function_id(self, mock_function_call_logs_response):
         res = FUNCTION_CALLS_API.get_logs(call_id=CALL_ID, function_id=FUNCTION_ID)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -157,8 +157,8 @@ def mock_functions_call_responses(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=CALL_RUNNING)
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/{CALL_ID}"
-    rsps.add(rsps.GET, url, status=200, json=CALL_COMPLETED)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/byids"
+    rsps.add(rsps.POST, url, status=200, json={"items": [CALL_COMPLETED]})
 
     yield rsps
 
@@ -361,7 +361,7 @@ class TestFunctionsAPI:
     def test_function_call(self, mock_functions_call_responses):
         res = FUNCTIONS_API.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_responses.calls[1].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_responses.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
     def test_function_call_by_external_id(self, mock_functions_call_by_external_id_responses):
         res = FUNCTIONS_API.call(external_id=f"func-no-{FUNCTION_ID}")


### PR DESCRIPTION
to make use of `self._retrieve_multiple` from the BaseAPI class, as we now have implemented the `functions/call_id/calls/byids` endpoint.

Is smoke tested in 
API: https://github.com/cognitedata/context-api/pull/1371

Bumps version to 0.36.0