### PR TITLE
[MLOPS-626] Adding `limits`-argument to `list` methods. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,18 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased]
+## [0.36] - 2020-01-05
+### Changed
+- The `FunctionCallAPI.retrieve` method now utilizes `retrieve_multiple` in the backend. `/calls` -> `/calls/byids`
 ### Added
 - Method `retrieve` to `FunctionScheduleAPI`-class.
 
-## [0.35] - 2012-12-14
-## Added
+## [0.35] - 2020-12-14
+### Added
 - Added IntegrationsAPI and IntegrationRunsAPI
 
-## [0.34] - 2012-12-08
-## Added
+## [0.34] - 2020-12-08
+### Added
 - Added relationships_label and use_existing_matches to pipelines
 
 ## [0.33.0] - 2020-12-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.37] - 2020-01-06
+### Changed
+- The following methods now accepts a `limit`-parameter, with default of 25, that controls how many elements the methods return:
+`FunctionCallAPI.list`, `FunctionAPI.list`, and `FunctionScheduleAPI.list`.
+
 ## [0.36] - 2020-01-05
 ### Changed
 - The `FunctionCallAPI.retrieve` method now utilizes `retrieve_multiple` in the backend. `/calls` -> `/calls/byids`

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -387,6 +387,8 @@ def _validate_function_handle(function_handle):
 
 
 class FunctionCallsAPI(APIClient):
+    _LIST_CLASS = FunctionCallList
+
     def list(
         self,
         function_id: Optional[int] = None,
@@ -436,8 +438,8 @@ class FunctionCallsAPI(APIClient):
 
     def retrieve(
         self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None
-    ) -> FunctionCall:
-        """`Retrieve call by id. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-function_name-calls-call_id>`_
+    ) -> Optional[FunctionCall]:
+        """`Retrieve a single function call by id. <https://docs.cognite.com/api/playground/#operation/byidsFunctionCalls>`_
 
         Args:
             call_id (int): ID of the call.
@@ -445,11 +447,11 @@ class FunctionCallsAPI(APIClient):
             function_external_id (str, optional): External ID of the function on which the call was made.
 
         Returns:
-            FunctionCall: Function call.
+            Optional[FunctionCall]: Requested function call.
 
         Examples:
 
-            Retrieve function call by id::
+            Retrieve single function call by id::
 
                 >>> from cognite.experimental import CogniteClient
                 >>> c = CogniteClient()
@@ -466,9 +468,8 @@ class FunctionCallsAPI(APIClient):
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
-        url = f"/functions/{function_id}/calls/{call_id}"
-        res = self._get(url)
-        return FunctionCall._load(res.json(), cognite_client=self._cognite_client)
+        resource_path = f"/functions/{function_id}/calls"
+        return self._retrieve_multiple(wrap_ids=True, resource_path=resource_path, ids=call_id)
 
     def get_response(self, call_id: int, function_id: Optional[int] = None, function_external_id: Optional[str] = None):
         """Retrieve the response from a function call.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -24,7 +24,7 @@ from cognite.experimental.data_classes import (
 )
 
 LIST_LIMIT_DEFAULT = 25
-
+LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf or -1.
 HANDLER_FILE_NAME = "handler.py"
 MAX_RETRIES = 5
 
@@ -168,7 +168,7 @@ class FunctionsAPI(APIClient):
         """`List all functions. <https://docs.cognite.com/api/playground/#operation/get-function>`_
 
         Args:
-            limit (int, optional): Maximum number of functions to list. Pass in -1, 'inf' or None to list all functions.
+            limit (int, optional): Maximum number of functions to list. Pass in -1, float('inf') or None to list all functions.
 
         Returns:
             FunctionList: List of functions
@@ -183,8 +183,8 @@ class FunctionsAPI(APIClient):
         """
         url = "/functions"
 
-        if limit in ["inf", -1]:
-            limit = None
+        if limit in [float("inf"), -1, None]:
+            limit = LIST_LIMIT_CEILING
 
         params = {"limit": limit}
         res = self._get(url, params=params)
@@ -412,7 +412,7 @@ class FunctionCallsAPI(APIClient):
         """List all calls associated with a specific function id. Either function_id or function_external_id must be specified.
 
         Args:
-            limit (int, optional): Maximum number of function calls to list. Pass in -1, 'inf' or None to list all Function Calls.
+            limit (int, optional): Maximum number of function calls to list. Pass in -1, float('inf') or None to list all Function Calls.
             function_id (int, optional): ID of the function on which the calls were made.
             function_external_id (str, optional): External ID of the function on which the calls were made.
             status (str, optional): Status of the call. Possible values ["Running", "Failed", "Completed", "Timeout"].
@@ -583,7 +583,7 @@ class FunctionSchedulesAPI(APIClient):
         """`List all schedules associated with a specific project. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-schedules>`_
 
         Args:
-            limit (int, optional): Maximum number of schedules to list. Pass in -1, 'inf' or None to list all schedules.
+            limit (int, optional): Maximum number of schedules to list. Pass in -1, float('inf') or None to list all schedules.
 
         Returns:
             FunctionSchedulesList: List of function schedules
@@ -606,8 +606,8 @@ class FunctionSchedulesAPI(APIClient):
         """
         url = f"/functions/schedules"
 
-        if limit in ["inf", -1]:
-            limit = None
+        if limit in [float("inf"), -1, None]:
+            limit = LIST_LIMIT_CEILING
 
         params = {"limit": limit}
         res = self._get(url, params=params)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -572,8 +572,11 @@ class FunctionSchedulesAPI(APIClient):
         utils._auxiliary.assert_exactly_one_of_id_or_external_id(id=id, external_id=None)
         return self._retrieve_multiple(ids=id, wrap_ids=True)
 
-    def list(self) -> FunctionSchedulesList:
+    def list(self, limit: Optional[int] = 25) -> FunctionSchedulesList:
         """`List all schedules associated with a specific project. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-schedules>`_
+
+        Args:
+            limit (int, optional): Maximum number of schedules to list.
 
         Returns:
             FunctionSchedulesList: List of function schedules
@@ -595,7 +598,8 @@ class FunctionSchedulesAPI(APIClient):
 
         """
         url = f"/functions/schedules"
-        res = self._get(url)
+        params = {"limit": limit}
+        res = self._get(url, params=params)
         return FunctionSchedulesList._load(res.json()["items"])
 
     def create(

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -168,7 +168,7 @@ class FunctionsAPI(APIClient):
         """`List all functions. <https://docs.cognite.com/api/playground/#operation/get-function>`_
 
         Args:
-            limit (int, optional): Maximum number of functions to list
+            limit (int, optional): Maximum number of functions to list. Pass in `inf`, `-1` or None to list all functions.
 
         Returns:
             FunctionList: List of functions
@@ -412,7 +412,7 @@ class FunctionCallsAPI(APIClient):
         """List all calls associated with a specific function id. Either function_id or function_external_id must be specified.
 
         Args:
-            limit (int, optional): Maximum number of function calls to list.
+            limit (int, optional): Maximum number of function calls to list. Pass in 'inf', -1 or None to list all Function Calls.
             function_id (int, optional): ID of the function on which the calls were made.
             function_external_id (str, optional): External ID of the function on which the calls were made.
             status (str, optional): Status of the call. Possible values ["Running", "Failed", "Completed", "Timeout"].
@@ -583,7 +583,7 @@ class FunctionSchedulesAPI(APIClient):
         """`List all schedules associated with a specific project. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-schedules>`_
 
         Args:
-            limit (int, optional): Maximum number of schedules to list.
+            limit (int, optional): Maximum number of schedules to list. Pass -1, 'inf' or None to list all schedules.
 
         Returns:
             FunctionSchedulesList: List of function schedules

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -182,6 +182,10 @@ class FunctionsAPI(APIClient):
                 >>> functions_list = c.functions.list()
         """
         url = "/functions"
+
+        if limit in ["inf", -1]:
+            limit = None
+
         params = {"limit": limit}
         res = self._get(url, params=params)
         return FunctionList._load(res.json()["items"], cognite_client=self._cognite_client)
@@ -601,6 +605,10 @@ class FunctionSchedulesAPI(APIClient):
 
         """
         url = f"/functions/schedules"
+
+        if limit in ["inf", -1]:
+            limit = None
+
         params = {"limit": limit}
         res = self._get(url, params=params)
         return FunctionSchedulesList._load(res.json()["items"])

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -168,7 +168,7 @@ class FunctionsAPI(APIClient):
         """`List all functions. <https://docs.cognite.com/api/playground/#operation/get-function>`_
 
         Args:
-            limit (int, optional): Maximum number of functions to list. Pass in `inf`, `-1` or None to list all functions.
+            limit (int, optional): Maximum number of functions to list. Pass in -1, 'inf' or None to list all functions.
 
         Returns:
             FunctionList: List of functions
@@ -412,7 +412,7 @@ class FunctionCallsAPI(APIClient):
         """List all calls associated with a specific function id. Either function_id or function_external_id must be specified.
 
         Args:
-            limit (int, optional): Maximum number of function calls to list. Pass in 'inf', -1 or None to list all Function Calls.
+            limit (int, optional): Maximum number of function calls to list. Pass in -1, 'inf' or None to list all Function Calls.
             function_id (int, optional): ID of the function on which the calls were made.
             function_external_id (str, optional): External ID of the function on which the calls were made.
             status (str, optional): Status of the call. Possible values ["Running", "Failed", "Completed", "Timeout"].
@@ -583,7 +583,7 @@ class FunctionSchedulesAPI(APIClient):
         """`List all schedules associated with a specific project. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-schedules>`_
 
         Args:
-            limit (int, optional): Maximum number of schedules to list. Pass -1, 'inf' or None to list all schedules.
+            limit (int, optional): Maximum number of schedules to list. Pass in -1, 'inf' or None to list all schedules.
 
         Returns:
             FunctionSchedulesList: List of function schedules

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -162,8 +162,11 @@ class FunctionsAPI(APIClient):
         """
         self._delete_multiple(ids=id, external_ids=external_id, wrap_ids=True)
 
-    def list(self) -> FunctionList:
+    def list(self, limit: Optional[int] = 25) -> FunctionList:
         """`List all functions. <https://docs.cognite.com/api/playground/#operation/get-function>`_
+
+        Args:
+            limit (int, optional): Maximum number of functions to list
 
         Returns:
             FunctionList: List of functions
@@ -177,7 +180,8 @@ class FunctionsAPI(APIClient):
                 >>> functions_list = c.functions.list()
         """
         url = "/functions"
-        res = self._get(url)
+        params = {"limit": limit}
+        res = self._get(url, params=params)
         return FunctionList._load(res.json()["items"], cognite_client=self._cognite_client)
 
     def retrieve(self, id: Optional[int] = None, external_id: Optional[str] = None) -> Optional[Function]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.36.0"
+version = "0.37.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.35.1"
+version = "0.36.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -467,6 +467,16 @@ def mock_function_schedules_response(rsps):
 
 
 @pytest.fixture
+def mock_function_schedules_response_with_limits(rsps):
+    limit = 1
+    query_params = f"?limit={limit}"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules" + query_params
+    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE1]})
+
+    yield rsps
+
+
+@pytest.fixture
 def mock_function_schedules_retrieve_response(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/schedules/byids"
     rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE1]})
@@ -512,6 +522,12 @@ class TestFunctionSchedulesAPI:
         expected = mock_function_schedules_response.calls[0].response.json()["items"]
         expected[0].pop("when")
         assert expected == res.dump(camel_case=True)
+
+    def test_list_schedules_with_limit(self, mock_function_schedules_response_with_limits):
+        res = FUNCTION_SCHEDULES_API.list(limit=1)
+
+        assert isinstance(res, FunctionSchedulesList)
+        assert len(res) == 1
 
     def test_create_schedules(self, mock_function_schedules_response):
         res = FUNCTION_SCHEDULES_API.create(

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -93,6 +93,17 @@ def mock_functions_list_response(rsps):
 
 
 @pytest.fixture
+def mock_function_list_response_with_limits(rsps):
+    response_body = {"items": [EXAMPLE_FUNCTION]}
+    limit = 1
+    query_params = f"?limit={limit}"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions" + query_params
+    rsps.add(rsps.GET, url, status=200, json=response_body)
+
+    yield rsps
+
+
+@pytest.fixture
 def mock_functions_retrieve_response(rsps):
     response_body = {"items": [EXAMPLE_FUNCTION]}
 
@@ -328,6 +339,12 @@ class TestFunctionsAPI:
 
         assert isinstance(res, FunctionList)
         assert mock_functions_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_list_with_limits(self, mock_function_list_response_with_limits):
+
+        res = FUNCTIONS_API.list(limit=1)
+        assert isinstance(res, FunctionList)
+        assert len(res) == 1
 
     def test_retrieve_by_id(self, mock_functions_retrieve_response):
         res = FUNCTIONS_API.retrieve(id=1)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -237,7 +237,7 @@ def mock_function_calls_filter_response(rsps):
 
 
 @pytest.fixture
-def mock_function_calls_list_response_with_limit(rsps):
+def mock_function_calls_filter_response_with_limit(rsps):
     response_body = {"items": [CALL_COMPLETED, CALL_SCHEDULED]}
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
     rsps.add(rsps.POST, url, status=200, json=response_body)
@@ -598,7 +598,7 @@ class TestFunctionCallsAPI:
         assert isinstance(res, FunctionCallList)
         assert mock_function_calls_filter_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
-    def test_list_calls_by_function_id_with_limits(self, mock_function_calls_list_response_with_limit):
+    def test_list_calls_by_function_id_with_limits(self, mock_function_calls_filter_response_with_limit):
         res = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID, limit=2)
         assert isinstance(res, FunctionCallList)
         assert len(res) == 2

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -236,6 +236,17 @@ def mock_function_calls_list_response(rsps):
     yield rsps
 
 
+@pytest.fixture
+def mock_function_calls_list_response_with_limit(rsps):
+    response_body = {"items": [CALL_COMPLETED, CALL_SCHEDULED]}
+    limit = 2
+    query_parameters = f"?limit={limit}"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
+    rsps.add(rsps.POST, url, status=200, json=response_body)
+
+    yield rsps
+
+
 class TestFunctionsAPI:
     @pytest.mark.parametrize(
         "function_folder, function_path, exception",
@@ -589,6 +600,11 @@ class TestFunctionCallsAPI:
         res = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID, **filter_kwargs)
         assert isinstance(res, FunctionCallList)
         assert mock_function_calls_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_list_calls_by_function_id_with_limits(self, mock_function_calls_list_response_with_limit):
+        res = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID, limit=2)
+        assert isinstance(res, FunctionCallList)
+        assert len(res) == 2
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_list_calls_by_function_external_id(self, mock_function_calls_list_response):

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -157,8 +157,8 @@ def mock_functions_call_responses(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=CALL_RUNNING)
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/{CALL_ID}"
-    rsps.add(rsps.GET, url, status=200, json=CALL_COMPLETED)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/byids"
+    rsps.add(rsps.POST, url, status=200, json={"items": [CALL_COMPLETED]})
 
     yield rsps
 
@@ -170,8 +170,8 @@ def mock_functions_call_by_external_id_responses(mock_functions_retrieve_respons
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/call"
     rsps.add(rsps.POST, url, status=201, json=CALL_RUNNING)
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/{CALL_ID}"
-    rsps.add(rsps.GET, url, status=200, json=CALL_COMPLETED)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/byids"
+    rsps.add(rsps.POST, url, status=200, json={"items": [CALL_COMPLETED]})
 
     yield rsps
 
@@ -361,13 +361,15 @@ class TestFunctionsAPI:
     def test_function_call(self, mock_functions_call_responses):
         res = FUNCTIONS_API.call(id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_responses.calls[1].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_responses.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
     def test_function_call_by_external_id(self, mock_functions_call_by_external_id_responses):
         res = FUNCTIONS_API.call(external_id=f"func-no-{FUNCTION_ID}")
 
         assert isinstance(res, FunctionCall)
-        assert mock_functions_call_by_external_id_responses.calls[2].response.json() == res.dump(camel_case=True)
+        assert mock_functions_call_by_external_id_responses.calls[2].response.json()["items"][0] == res.dump(
+            camel_case=True
+        )
 
     def test_function_call_failed(self, mock_functions_call_failed_response):
         res = FUNCTIONS_API.call(id=FUNCTION_ID)
@@ -383,8 +385,8 @@ class TestFunctionsAPI:
 @pytest.fixture
 def mock_function_calls_retrieve_response(rsps):
     response_body = CALL_COMPLETED
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/{CALL_ID}"
-    rsps.add(rsps.GET, url, status=200, json=response_body)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/byids"
+    rsps.add(rsps.POST, url, status=200, json={"items": [response_body]})
 
     yield rsps
 
@@ -564,13 +566,13 @@ class TestFunctionCallsAPI:
     def test_retrieve_call_by_function_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
-        assert mock_function_calls_retrieve_response.calls[0].response.json() == res.dump(camel_case=True)
+        assert mock_function_calls_retrieve_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
     def test_retrieve_call_by_function_external_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCall)
-        assert mock_function_calls_retrieve_response.calls[1].response.json() == res.dump(camel_case=True)
+        assert mock_function_calls_retrieve_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
     def test_function_call_logs_by_function_id(self, mock_function_call_logs_response):
         res = FUNCTION_CALLS_API.get_logs(call_id=CALL_ID, function_id=FUNCTION_ID)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -98,7 +98,7 @@ def mock_function_list_response_with_limits(rsps):
     limit = 1
     query_params = f"?limit={limit}"
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions" + query_params
-    rsps.add(rsps.GET, url, status=200, json=response_body)
+    rsps.add(rsps.GET, url, status=200, json=response_body, match_querystring=True)
 
     yield rsps
 
@@ -482,8 +482,7 @@ def mock_function_schedules_response_with_limits(rsps):
     limit = 1
     query_params = f"?limit={limit}"
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules" + query_params
-    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE1]})
-
+    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE1]}, match_querystring=True)
     yield rsps
 
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -239,7 +239,6 @@ def mock_function_calls_list_response(rsps):
 @pytest.fixture
 def mock_function_calls_list_response_with_limit(rsps):
     response_body = {"items": [CALL_COMPLETED, CALL_SCHEDULED]}
-    limit = 2
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
     rsps.add(rsps.POST, url, status=200, json=response_body)
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -228,7 +228,7 @@ def function_handle_illegal_argument():
 
 
 @pytest.fixture
-def mock_function_calls_list_response(rsps):
+def mock_function_calls_filter_response(rsps):
     response_body = {"items": [CALL_COMPLETED, CALL_SCHEDULED]}
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
     rsps.add(rsps.POST, url, status=200, json=response_body)
@@ -575,7 +575,7 @@ class TestFunctionSchedulesAPI:
 
 
 class TestFunctionCallsAPI:
-    def test_list_calls_and_filter(self, mock_function_calls_list_response, mock_functions_retrieve_response):
+    def test_list_calls_and_filter(self, mock_function_calls_filter_response, mock_functions_retrieve_response):
         filter_kwargs = {
             "status": "Completed",
             "schedule_id": 123,
@@ -585,9 +585,9 @@ class TestFunctionCallsAPI:
         res = FUNCTIONS_API.retrieve(id=FUNCTION_ID).list_calls(**filter_kwargs)
 
         assert isinstance(res, FunctionCallList)
-        assert mock_function_calls_list_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_calls_filter_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
 
-    def test_list_calls_by_function_id(self, mock_function_calls_list_response):
+    def test_list_calls_by_function_id(self, mock_function_calls_filter_response):
         filter_kwargs = {
             "status": "Completed",
             "schedule_id": 123,
@@ -596,7 +596,7 @@ class TestFunctionCallsAPI:
         }
         res = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID, **filter_kwargs)
         assert isinstance(res, FunctionCallList)
-        assert mock_function_calls_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_calls_filter_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
     def test_list_calls_by_function_id_with_limits(self, mock_function_calls_list_response_with_limit):
         res = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID, limit=2)
@@ -604,10 +604,10 @@ class TestFunctionCallsAPI:
         assert len(res) == 2
 
     @pytest.mark.usefixtures("mock_functions_retrieve_response")
-    def test_list_calls_by_function_external_id(self, mock_function_calls_list_response):
+    def test_list_calls_by_function_external_id(self, mock_function_calls_filter_response):
         res = FUNCTION_CALLS_API.list(function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCallList)
-        assert mock_function_calls_list_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_function_calls_filter_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
 
     def test_retrieve_call_by_function_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
@@ -638,7 +638,7 @@ class TestFunctionCallsAPI:
         assert isinstance(logs, FunctionCallLog)
         assert mock_function_call_logs_response.calls[1].response.json()["items"] == logs.dump(camel_case=True)
 
-    @pytest.mark.usefixtures("mock_function_calls_list_response")
+    @pytest.mark.usefixtures("mock_function_calls_filter_response")
     def test_get_logs_on_listed_call_object(self, mock_function_call_logs_response):
         calls = FUNCTION_CALLS_API.list(function_id=FUNCTION_ID)
         call = calls[0]

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -240,7 +240,6 @@ def mock_function_calls_list_response(rsps):
 def mock_function_calls_list_response_with_limit(rsps):
     response_body = {"items": [CALL_COMPLETED, CALL_SCHEDULED]}
     limit = 2
-    query_parameters = f"?limit={limit}"
     url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/{FUNCTION_ID}/calls/list"
     rsps.add(rsps.POST, url, status=200, json=response_body)
 


### PR DESCRIPTION
This PR introduces the possibility of specifying a `limit` in the `list`-methods of `FunctionsAPI`, `FunctionsCallAPI`, and `FunctionsScheduleAPI`. If not specified, the `limit`-default is controlled by `LIST_LIMIT_DEFAULT` and is set to 25. 

