### PR TITLE
[MLOPS-631] Added zero as a valid list limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.45.1]
+
+### Fixed
+
+- Added 0 as a valid limit parameter to `functions.list`, `functions.calls.list` and `functions.schedules.list`. A limit of 0 yields all items
+in return, akin to limit equal to 0, None and float("inf")
+
 ## [0.45.0]
 
 ### Added

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -444,10 +444,6 @@ class FunctionCallsAPI(APIClient):
         filter = {"status": status, "scheduleId": schedule_id, "startTime": start_time, "endTime": end_time}
         resource_path = f"/functions/{function_id}/calls"
 
-        # We must set this here, because the self._list-method does not handle `0` as a limit.
-        if limit == 0:
-            limit = None
-
         return self._list(method="POST", resource_path=resource_path, filter=filter, limit=limit)
 
     def retrieve(

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -167,7 +167,7 @@ class FunctionsAPI(APIClient):
         """`List all functions. <https://docs.cognite.com/api/playground/#operation/get-function>`_
 
         Args:
-            limit (int, optional): Maximum number of functions to list. Pass in -1, float('inf') or None to list all functions.
+            limit (int, optional): Maximum number of functions to list. Pass in -1, 0, float('inf') or None to list all functions.
 
         Returns:
             FunctionList: List of functions

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -182,7 +182,7 @@ class FunctionsAPI(APIClient):
         """
         url = "/functions"
 
-        if limit in [float("inf"), -1, None]:
+        if limit in [float("inf"), -1, None, 0]:
             limit = LIST_LIMIT_CEILING
 
         params = {"limit": limit}
@@ -417,7 +417,7 @@ class FunctionCallsAPI(APIClient):
             schedule_id (int, optional): Schedule id from which the call belongs (if any).
             start_time (Dict[str, int], optional): Start time of the call. Possible keys are `min` and `max`, with values given as time stamps in ms.
             end_time (Dict[str, int], optional): End time of the call. Possible keys are `min` and `max`, with values given as time stamps in ms.
-            limit (int, optional): Maximum number of function calls to list. Pass in -1, float('inf') or None to list all Function Calls.
+            limit (int, optional): Maximum number of function calls to list. Pass in -1, 0, float('inf') or None to list all Function Calls.
 
         Returns:
             FunctionCallList: List of function calls
@@ -443,6 +443,10 @@ class FunctionCallsAPI(APIClient):
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         filter = {"status": status, "scheduleId": schedule_id, "startTime": start_time, "endTime": end_time}
         resource_path = f"/functions/{function_id}/calls"
+
+        # We must set this here, because the self._list-method does not handle `0` as a limit.
+        if limit == 0:
+            limit = None
 
         return self._list(method="POST", resource_path=resource_path, filter=filter, limit=limit)
 
@@ -582,7 +586,7 @@ class FunctionSchedulesAPI(APIClient):
         """`List all schedules associated with a specific project. <https://docs.cognite.com/api/playground/#operation/get-api-playground-projects-project-functions-schedules>`_
 
         Args:
-            limit (int, optional): Maximum number of schedules to list. Pass in -1, float('inf') or None to list all schedules.
+            limit (int, optional): Maximum number of schedules to list. Pass in -1, 0, float('inf') or None to list all schedules.
 
         Returns:
             FunctionSchedulesList: List of function schedules
@@ -605,7 +609,7 @@ class FunctionSchedulesAPI(APIClient):
         """
         url = f"/functions/schedules"
 
-        if limit in [float("inf"), -1, None]:
+        if limit in [float("inf"), -1, None, 0]:
             limit = LIST_LIMIT_CEILING
 
         params = {"limit": limit}

--- a/cognite/experimental/_constants.py
+++ b/cognite/experimental/_constants.py
@@ -1,5 +1,5 @@
 # Functions
 LIST_LIMIT_DEFAULT = 25
-LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf or -1.
+LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf, 0 or -1.
 HANDLER_FILE_NAME = "handler.py"
 MAX_RETRIES = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.45.0"
+version = "0.45.1"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
Users expected a limit=0 to function the same as limit=None/float("inf")/-1.

- Added 0 as a valid limit parameter to the list-endpoints. Functions as limit = -1, None or float(inf)
- Bumped version to 0.45.1
