### PR TITLE
Change IntegrationRuns list method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.46.0]
+
+### Added
+- Add functionality to add/remove elements in integration list fields. 
+
 ## [0.45.0]
 
 ### Added

--- a/INTEGRATIONS&RUNS.MD
+++ b/INTEGRATIONS&RUNS.MD
@@ -34,6 +34,8 @@ res = client.integrations.update(res)
 from cognite.experimental.data_classes import IntegrationUpdate	
 up = IntegrationUpdate(id=res.id)
 up.description.set("Another new integration")
+up.raw_tables.add([{"dbName": "name", "tableName": "name"}])
+up.raw_tables.remove([{"dbName": "old_name", "tableName": "old_name"}])
 res = client.integrations.update(up)
 ```
 

--- a/cognite/experimental/_api/integrationruns.py
+++ b/cognite/experimental/_api/integrationruns.py
@@ -3,17 +3,12 @@ from typing import *
 from cognite.client import utils
 from cognite.client._api_client import APIClient
 
-from cognite.experimental.data_classes import (
-    IntegrationRun,
-    IntegrationRunList,
-    IntegrationWithStatuses,
-    IntegrationWithStatusesList,
-)
+from cognite.experimental.data_classes import IntegrationRun, IntegrationRunList
 
 
 class IntegrationsRunsAPI(APIClient):
     _RESOURCE_PATH = "/integrations/runs"
-    _LIST_CLASS = IntegrationWithStatusesList
+    _LIST_CLASS = IntegrationRunList
 
     def list(self, external_id: str, limit: int = 25) -> IntegrationRunList:
         """`List of runs for integration with given external_id <>`_
@@ -35,12 +30,7 @@ class IntegrationsRunsAPI(APIClient):
                 >>> runsList = c.integration_runs.list(external_id="test ext id", limit=5)
         """
 
-        self._LIST_CLASS = IntegrationWithStatusesList
-        response_list: IntegrationWithStatusesList
-        response_list = self._list(method="GET", limit=limit, filter={"externalId": external_id})
-        if len(response_list) == 1:
-            return response_list[0].runs()
-        return IntegrationRunList([])
+        return self._list(method="GET", limit=limit, filter={"externalId": external_id})
 
     def create(self, run: Union[IntegrationRun, List[IntegrationRun]]) -> Union[IntegrationRun, IntegrationRunList]:
         """`Create one or more integrationRuns. <>`_
@@ -63,6 +53,5 @@ class IntegrationsRunsAPI(APIClient):
                 >>> integrationRuns = [IntegrationRun(status="success", external_id="extId"),...]
                 >>> res = c.integration_runs.create(integrationRuns)
         """
-        self._LIST_CLASS = IntegrationRunList
         utils._auxiliary.assert_type(run, "run", [IntegrationRun, list])
         return self._create_multiple(run)

--- a/cognite/experimental/data_classes/integrationruns.py
+++ b/cognite/experimental/data_classes/integrationruns.py
@@ -1,38 +1,6 @@
 from cognite.client.data_classes._base import *
 
 
-class IntegrationWithStatuses(CogniteResource):
-    """A representation of a response with list of Runs.
-
-    Args:
-        external_id (str): The external ID of related integration provided by the client. Must be unique for the resource type.
-        statuses (List[Dict[str, Any]]): List of Runs represented as statuses.
-        cognite_client (CogniteClient): The client to associate with this object.
-    """
-
-    def __init__(
-        self, external_id: str = None, statuses: List[Dict[str, Any]] = None, cognite_client=None,
-    ):
-        setattr(self, "external_id", external_id),
-        self.statuses = (statuses,)
-        self._cognite_client = cognite_client
-
-    @classmethod
-    def _load(cls, resource: Union[Dict, str], cognite_client=None):
-        instance = super(IntegrationWithStatuses, cls)._load(resource, cognite_client)
-        return instance
-
-    def runs(self):
-        result: List[IntegrationRun] = []
-        if len(self.statuses) > 0:
-            for status in self.statuses:
-                if not (status is None):
-                    result.append(
-                        IntegrationRun(self.external_id, status["status"], status.get("message"), status["createdTime"])
-                    )
-        return result
-
-
 class IntegrationRun(CogniteResource):
     """A representation of a IntegrationRun.
 
@@ -69,11 +37,6 @@ class IntegrationRunUpdate(CogniteUpdate):
     class _PrimitiveIntegrationRunUpdate(CognitePrimitiveUpdate):
         def set(self, value: Any) -> "IntegrationRunUpdate":
             return self._set(value)
-
-
-class IntegrationWithStatusesList(CogniteResourceList):
-    _RESOURCE = IntegrationWithStatuses
-    _UPDATE = IntegrationWithStatusesUpdate
 
 
 class IntegrationRunList(CogniteResourceList):

--- a/cognite/experimental/data_classes/integrations.py
+++ b/cognite/experimental/data_classes/integrations.py
@@ -80,6 +80,26 @@ class IntegrationUpdate(CogniteUpdate):
         def set(self, value: Any) -> "IntegrationUpdate":
             return self._set(value)
 
+    class _ObjectIntegrationUpdate(CogniteObjectUpdate):
+        def set(self, value: Dict) -> "IntegrationUpdate":
+            return self._set(value)
+
+        def add(self, value: Dict) -> "IntegrationUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "IntegrationUpdate":
+            return self._remove(value)
+
+    class _ListIntegrationUpdate(CogniteListUpdate):
+        def set(self, value: List) -> "IntegrationUpdate":
+            return self._set(value)
+
+        def add(self, value: List) -> "IntegrationUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "IntegrationUpdate":
+            return self._remove(value)
+
     @property
     def external_id(self):
         return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "externalId")
@@ -98,11 +118,11 @@ class IntegrationUpdate(CogniteUpdate):
 
     @property
     def raw_tables(self):
-        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "rawTables")
+        return IntegrationUpdate._ListIntegrationUpdate(self, "rawTables")
 
     @property
     def metadata(self):
-        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "metadata")
+        return IntegrationUpdate._ObjectIntegrationUpdate(self, "metadata")
 
     @property
     def schedule(self):
@@ -110,7 +130,7 @@ class IntegrationUpdate(CogniteUpdate):
 
     @property
     def contacts(self):
-        return IntegrationUpdate._PrimitiveIntegrationUpdate(self, "contacts")
+        return IntegrationUpdate._ListIntegrationUpdate(self, "contacts")
 
 
 class IntegrationList(CogniteResourceList):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.45.1"
+version = "0.46.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_integrations.py
+++ b/tests/tests_unit/test_api/test_integrations.py
@@ -144,3 +144,15 @@ class TestIntegrations:
         assert {
             "items": [{"externalId": "py test id", "update": {"description": {"set": "New description"}}}]
         } == jsgz_load(mock_int_response.calls[0].request.body)
+
+    def test_update_raw_tables_with_update_class(self, mock_int_response):
+        up = IntegrationUpdate(external_id="py test id")
+        up.raw_tables.add([{"dbName": "db", "tableName": "table"}])
+        res = TEST_API.update(up)
+        assert isinstance(res, Integration)
+        assert mock_int_response.calls[0].response.json()["items"][0] == res.dump(camel_case=True)
+        assert {
+            "items": [
+                {"externalId": "py test id", "update": {"rawTables": {"add": [{"dbName": "db", "tableName": "table"}]}}}
+            ]
+        } == jsgz_load(mock_int_response.calls[0].request.body)

--- a/tests/tests_unit/test_api/test_runs.py
+++ b/tests/tests_unit/test_api/test_runs.py
@@ -3,12 +3,7 @@ import re
 import pytest
 
 from cognite.experimental import CogniteClient
-from cognite.experimental.data_classes import (
-    IntegrationRun,
-    IntegrationRunList,
-    IntegrationWithStatuses,
-    IntegrationWithStatusesList,
-)
+from cognite.experimental.data_classes import IntegrationRun, IntegrationRunList
 
 COGNITE_CLIENT = CogniteClient()
 TEST_API = COGNITE_CLIENT.integration_runs
@@ -18,17 +13,10 @@ TEST_API = COGNITE_CLIENT.integration_runs
 def mock_run_response(rsps):
     response_body = {
         "items": [
-            {
-                "externalId": "test",
-                "createdTime": 1606994621658,
-                "lastUpdatedTime": 1606994621658,
-                "statuses": [
-                    {"status": "seen", "createdTime": 1606994793386},
-                    {"status": "failure", "createdTime": 1606994773381, "message": "ERROR"},
-                    {"status": "success", "createdTime": 1606994743201},
-                    {"status": "seen", "createdTime": 1606994696151},
-                ],
-            }
+            {"status": "seen", "createdTime": 1606994793386},
+            {"status": "failure", "createdTime": 1606994773381, "message": "ERROR"},
+            {"status": "success", "createdTime": 1606994743201},
+            {"status": "seen", "createdTime": 1606994696151},
         ]
     }
     url_pattern = re.compile(


### PR DESCRIPTION
API has been updated to follow the convention of other endpoints (ie, JSON is on the form `{ "items" : [ ... ] }` with pagination). Update SDK accordingly. 

Originally from an external PR (#152), but because of limited access to api-keys in the tests it has to go through an extra branch/PR.