### PR TITLE
[MLOPS-679] Setting `limit=None` in `Function.list_schedules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.45.2]
+
+### Fixed
+
+- The `Function.list_schedules()`-method now correctly returns all schedules tied to the function.
+
 ## [0.45.0]
 
 ### Added

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -112,7 +112,7 @@ class Function(CogniteResource):
         Returns:
             FunctionSchedulesList: List of function schedules
         """
-        all_schedules = self._cognite_client.functions.schedules.list()
+        all_schedules = self._cognite_client.functions.schedules.list(limit=None)
         function_schedules = filter(lambda f: f.function_external_id == self.external_id, all_schedules)
         return list(function_schedules)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.45.1"
+version = "0.45.2"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
The `function.list_schedules` method was not updated accordingly when we changed the `limit`-defaults. We now pass `limit=None` to make sure we always get every schedule associated to the relevant function.﻿
