### PR TITLE
Expand functions schedules list filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,14 @@ Changes are grouped as follows
 
 ### Changed
 
-- The `FunctionsAPI.list()`-method now accepts additional filters: `name`, `owner`, `file_id`, `external_id_prefix` and `created_time`.
+- The `FunctionsAPI.list()`-method now accepts additional filters: `name`, `owner`, `file_id`, `status`, `external_id_prefix` and `created_time`.
 - The `FunctionSchedulesAPI.list()`-method now accepts additional filters: `name`, `function_external_id`, `created_time` and `cron_expression`.
 - The `Function.list_schedules()`-method now accepts `limit` argument.
 
 ## [0.46.0]
 
 ### Added
-- Add functionality to add/remove elements in integration list fields. 
+- Add functionality to add/remove elements in integration list fields.
 
 ## [0.45.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.46.0]
+
+### Changed
+
+- The `FunctionsAPI.list()`-method now accepts additional filters: `name`, `owner`, `file_id`, `external_id_prefix` and `created_time`.
+- The `FunctionSchedulesAPI.list()`-method now accepts additional filters: `name`, `function_external_id`, `created_time` and `cron_expression`.
+- The `Function.list_schedules()`-method now accepts `limit` argument.
+
 ## [0.45.2]
 
 ### Fixed
@@ -38,7 +46,7 @@ Changes are grouped as follows
 
 ## [0.42.0] - 21-02-01
 
-### Added 
+### Added
 - Template functionality.
 
 ### Removed
@@ -101,7 +109,7 @@ Changes are grouped as follows
 
 ## [0.33.0] - 2020-12-02
 ### Added
-- Method `get_input_data` on the `FunctionSchedule`-class. 
+- Method `get_input_data` on the `FunctionSchedule`-class.
 - Method `get_input_data` on the `FunctionScheduleAPI`-class.
 
 ## [0.32.0] - 2020-12-03
@@ -228,8 +236,8 @@ Changes are grouped as follows
 - Change list-method to list all models instead of jobs.
 - Changed endpoints used for list and list_jobs to comply with updates to the API.
 ### Added
-- Add list_jobs-method that behaves as old list-method, that is returns all jobs. 
-- Option to filter returned models on based on all input parameters. 
+- Add list_jobs-method that behaves as old list-method, that is returns all jobs.
+- Option to filter returned models on based on all input parameters.
 
 ## [0.15.4] - 2020-08-13
 ### Added
@@ -271,7 +279,7 @@ Changes are grouped as follows
 
 ## [0.14.1] - 2020-08-03
 ### Added
-- Added retry to functions POST endpoints. 
+- Added retry to functions POST endpoints.
 
 ## [0.14.0] - 2020-08-03
 ### Changed
@@ -398,8 +406,8 @@ Changes are grouped as follows
 ## [0.5.2] - 2020-04-16
 
 ### Added
-- A `FunctionSchedule` class and corresponding api attached to the `Functions` api to interact with function schedules. 
-Function schedules can now also be listed using the `Function` object through the `list_schedules` method. 
+- A `FunctionSchedule` class and corresponding api attached to the `Functions` api to interact with function schedules.
+Function schedules can now also be listed using the `Function` object through the `list_schedules` method.
 
 ## [0.5.1] - 2020-04-15
 

--- a/cognite/experimental/_constants.py
+++ b/cognite/experimental/_constants.py
@@ -1,5 +1,4 @@
 # Functions
 LIST_LIMIT_DEFAULT = 25
-LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf or -1.
 HANDLER_FILE_NAME = "handler.py"
 MAX_RETRIES = 5

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -2,7 +2,8 @@ import time
 from numbers import Number
 from typing import Dict, List, Optional, Union
 
-from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
+from cognite.client.data_classes._base import CogniteFilter, CogniteResource, CogniteResourceList
+from cognite.client.data_classes.shared import TimestampRange
 
 from cognite.experimental._constants import LIST_LIMIT_DEFAULT
 
@@ -142,6 +143,30 @@ class Function(CogniteResource):
                 continue
             latest_value = getattr(latest, attribute)
             setattr(self, attribute, latest_value)
+
+
+class FunctionFilter(CogniteFilter):
+    def __init__(
+        self,
+        name: str = None,
+        owner: str = None,
+        file_id: int = None,
+        external_id_prefix: str = None,
+        created_time: Union[Dict[str, int], TimestampRange] = None,
+    ):
+        self.name = name
+        self.owner = owner
+        self.file_id = file_id
+        self.external_id_prefix = external_id_prefix
+        self.created_time = created_time
+
+    @classmethod
+    def _load(cls, resource: Union[Dict, str], cognite_client=None):
+        instance = super(FunctionFilter, cls)._load(resource, cognite_client)
+        if isinstance(resource, dict):
+            if instance.created_time is not None:
+                instance.created_time = TimestampRange(**instance.created_time)
+        return instance
 
 
 class FunctionSchedule(CogniteResource):

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -152,22 +152,16 @@ class FunctionFilter(CogniteFilter):
         name: str = None,
         owner: str = None,
         file_id: int = None,
+        status: str = None,
         external_id_prefix: str = None,
         created_time: Union[Dict[str, int], TimestampRange] = None,
     ):
         self.name = name
         self.owner = owner
         self.file_id = file_id
+        self.status = status
         self.external_id_prefix = external_id_prefix
         self.created_time = created_time
-
-    @classmethod
-    def _load(cls, resource: Union[Dict, str], cognite_client=None):
-        instance = super(FunctionFilter, cls)._load(resource, cognite_client)
-        if isinstance(resource, dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-        return instance
 
 
 class FunctionSchedule(CogniteResource):
@@ -224,14 +218,6 @@ class FunctionSchedulesFilter(CogniteFilter):
         self.function_external_id = function_external_id
         self.created_time = created_time
         self.cron_expression = cron_expression
-
-    @classmethod
-    def _load(cls, resource: Union[Dict, str], cognite_client=None):
-        instance = super(FunctionSchedulesFilter, cls)._load(resource, cognite_client)
-        if isinstance(resource, dict):
-            if instance.created_time is not None:
-                instance.created_time = TimestampRange(**instance.created_time)
-        return instance
 
 
 class FunctionSchedulesList(CogniteResourceList):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.45.2"
+version = "0.46.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.46.0"
+version = "0.47.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -93,17 +93,6 @@ def mock_functions_list_response(rsps):
 
 
 @pytest.fixture
-def mock_function_list_response_with_limits(rsps):
-    response_body = {"items": [EXAMPLE_FUNCTION]}
-    limit = 1
-    query_params = f"?limit={limit}"
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions" + query_params
-    rsps.add(rsps.GET, url, status=200, json=response_body, match_querystring=True)
-
-    yield rsps
-
-
-@pytest.fixture
 def mock_functions_retrieve_response(rsps):
     response_body = {"items": [EXAMPLE_FUNCTION]}
 
@@ -349,7 +338,7 @@ class TestFunctionsAPI:
         assert isinstance(res, FunctionList)
         assert mock_functions_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
-    def test_list_with_limits(self, mock_function_list_response_with_limits):
+    def test_list_with_limits(self, mock_functions_list_response):
 
         res = FUNCTIONS_API.list(limit=1)
         assert isinstance(res, FunctionList)
@@ -464,21 +453,20 @@ SCHEDULE2 = {
 
 
 @pytest.fixture
-def mock_function_schedules_response(rsps):
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules"
-    rsps.assert_all_requests_are_fired = False
-    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE1]})
+def mock_function_schedules_list_response(rsps):
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules/list"
     rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE1]})
 
     yield rsps
 
 
 @pytest.fixture
-def mock_function_schedules_response_with_limits(rsps):
-    limit = 1
-    query_params = f"?limit={limit}"
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules" + query_params
-    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE1]}, match_querystring=True)
+def mock_function_schedules_response(rsps):
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules"
+    rsps.assert_all_requests_are_fired = False
+    rsps.add(rsps.GET, url, status=200, json={"items": [SCHEDULE1]})
+    rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE1]})
+
     yield rsps
 
 
@@ -522,14 +510,14 @@ class TestFunctionSchedulesAPI:
         expected.pop("when")
         assert expected == res.dump(camel_case=True)
 
-    def test_list_schedules(self, mock_function_schedules_response):
+    def test_list_schedules(self, mock_function_schedules_list_response):
         res = FUNCTION_SCHEDULES_API.list()
         assert isinstance(res, FunctionSchedulesList)
         expected = mock_function_schedules_response.calls[0].response.json()["items"]
         expected[0].pop("when")
         assert expected == res.dump(camel_case=True)
 
-    def test_list_schedules_with_limit(self, mock_function_schedules_response_with_limits):
+    def test_list_schedules_with_limit(self, mock_function_schedules_list_response):
         res = FUNCTION_SCHEDULES_API.list(limit=1)
 
         assert isinstance(res, FunctionSchedulesList)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -1,6 +1,5 @@
-import json
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -87,8 +86,8 @@ CALL_SCHEDULED = {
 def mock_functions_list_response(rsps):
     response_body = {"items": [EXAMPLE_FUNCTION]}
 
-    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions"
-    rsps.add(rsps.GET, url, status=200, json=response_body)
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/list"
+    rsps.add(rsps.POST, url, status=200, json=response_body)
 
     yield rsps
 
@@ -331,15 +330,15 @@ class TestFunctionsAPI:
             FUNCTIONS_API.create(name="myfunction", file_id=1234, memory="0.5")
 
     def test_delete_single_id(self, mock_functions_delete_response):
-        res = FUNCTIONS_API.delete(id=1)
+        _ = FUNCTIONS_API.delete(id=1)
         assert {"items": [{"id": 1}]} == jsgz_load(mock_functions_delete_response.calls[0].request.body)
 
     def test_delete_single_external_id(self, mock_functions_delete_response):
-        res = FUNCTIONS_API.delete(external_id="func1")
+        _ = FUNCTIONS_API.delete(external_id="func1")
         assert {"items": [{"externalId": "func1"}]} == jsgz_load(mock_functions_delete_response.calls[0].request.body)
 
     def test_delete_multiple_id_and_multiple_external_id(self, mock_functions_delete_response):
-        res = FUNCTIONS_API.delete(id=[1, 2, 3], external_id=["func1", "func2"])
+        _ = FUNCTIONS_API.delete(id=[1, 2, 3], external_id=["func1", "func2"])
         assert {
             "items": [{"id": 1}, {"id": 2}, {"id": 3}, {"externalId": "func1"}, {"externalId": "func2"}]
         } == jsgz_load(mock_functions_delete_response.calls[0].request.body)
@@ -485,7 +484,7 @@ def mock_function_schedules_response_with_limits(rsps):
 
 @pytest.fixture
 def mock_function_schedules_retrieve_response(rsps):
-    url = FUNCTIONS_API._get_base_url_with_base_path() + f"/functions/schedules/byids"
+    url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules/byids"
     rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE1]})
 
     yield rsps
@@ -563,7 +562,7 @@ class TestFunctionSchedulesAPI:
 
     def test_delete_schedules(self, mock_function_schedules_delete_response):
         res = FUNCTION_SCHEDULES_API.delete(id=8012683333564363)
-        assert None == res
+        assert res is None
 
     def test_schedule_get_data(self, mock_schedule_get_data_response):
         res = FUNCTION_SCHEDULES_API.get_input_data(id=8012683333564363)

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -513,7 +513,7 @@ class TestFunctionSchedulesAPI:
     def test_list_schedules(self, mock_function_schedules_list_response):
         res = FUNCTION_SCHEDULES_API.list()
         assert isinstance(res, FunctionSchedulesList)
-        expected = mock_function_schedules_response.calls[0].response.json()["items"]
+        expected = mock_function_schedules_list_response.calls[0].response.json()["items"]
         expected[0].pop("when")
         assert expected == res.dump(camel_case=True)
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -83,7 +83,7 @@ CALL_SCHEDULED = {
 
 
 @pytest.fixture
-def mock_functions_list_response(rsps):
+def mock_functions_filter_response(rsps):
     response_body = {"items": [EXAMPLE_FUNCTION]}
 
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/list"
@@ -332,13 +332,13 @@ class TestFunctionsAPI:
             "items": [{"id": 1}, {"id": 2}, {"id": 3}, {"externalId": "func1"}, {"externalId": "func2"}]
         } == jsgz_load(mock_functions_delete_response.calls[0].request.body)
 
-    def test_list(self, mock_functions_list_response):
+    def test_list(self, mock_functions_filter_response):
         res = FUNCTIONS_API.list()
 
         assert isinstance(res, FunctionList)
-        assert mock_functions_list_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
+        assert mock_functions_filter_response.calls[0].response.json()["items"] == res.dump(camel_case=True)
 
-    def test_list_with_limits(self, mock_functions_list_response):
+    def test_list_with_limits(self, mock_functions_filter_response):
 
         res = FUNCTIONS_API.list(limit=1)
         assert isinstance(res, FunctionList)
@@ -453,7 +453,7 @@ SCHEDULE2 = {
 
 
 @pytest.fixture
-def mock_function_schedules_list_response(rsps):
+def mock_filter_function_schedules_response(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/functions/schedules/list"
     rsps.add(rsps.POST, url, status=200, json={"items": [SCHEDULE1]})
 
@@ -510,14 +510,14 @@ class TestFunctionSchedulesAPI:
         expected.pop("when")
         assert expected == res.dump(camel_case=True)
 
-    def test_list_schedules(self, mock_function_schedules_list_response):
+    def test_list_schedules(self, mock_filter_function_schedules_response):
         res = FUNCTION_SCHEDULES_API.list()
         assert isinstance(res, FunctionSchedulesList)
-        expected = mock_function_schedules_list_response.calls[0].response.json()["items"]
+        expected = mock_filter_function_schedules_response.calls[0].response.json()["items"]
         expected[0].pop("when")
         assert expected == res.dump(camel_case=True)
 
-    def test_list_schedules_with_limit(self, mock_function_schedules_list_response):
+    def test_list_schedules_with_limit(self, mock_filter_function_schedules_response):
         res = FUNCTION_SCHEDULES_API.list(limit=1)
 
         assert isinstance(res, FunctionSchedulesList)


### PR DESCRIPTION
Moves `functions/list` and `schedules/list` from `get` to `post` to allow server side filtering.

Also fixed wrong return types (e.g. `list` not pretty-printing in notebooks, before on the bottom, new on top):

<img width="838" alt="Screenshot 2021-02-27 at 14 21 01" src="https://user-images.githubusercontent.com/8521241/109388417-20fb3c80-7907-11eb-88e0-d90b1cf91b6f.png">

Bumping version to 0.47.0