### PR TITLE
Fix missing client from _load in func.list and schedules.list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.48.2]
+
+### Fixed
+- `FunctionsAPI.list()` and `FunctionSchedulesAPI.list()` were missing `cognite_client` from a bug introduced in version [0.47.0].
+
 ## [0.48.1]
 
 ### Fixed

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -1,5 +1,4 @@
 import importlib.util
-import json
 import os
 import sys
 import time
@@ -7,7 +6,7 @@ from inspect import getsource
 from numbers import Number
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 from zipfile import ZipFile
 
 from cognite.client import utils
@@ -213,7 +212,7 @@ class FunctionsAPI(APIClient):
         ).dump(camel_case=True)
         res = self._post(url_path=f"{self._RESOURCE_PATH}/list", json={"filter": filter, "limit": limit})
 
-        return self._LIST_CLASS._load(res.json()["items"])
+        return self._LIST_CLASS._load(res.json()["items"], cognite_client=self._cognite_client)
 
     def retrieve(self, id: Optional[int] = None, external_id: Optional[str] = None) -> Optional[Function]:
         """`Retrieve a single function by id. <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-context-functions-byids>`_
@@ -651,7 +650,7 @@ class FunctionSchedulesAPI(APIClient):
         ).dump(camel_case=True)
         res = self._post(url_path=f"{self._RESOURCE_PATH}/list", json={"filter": filter, "limit": limit})
 
-        return self._LIST_CLASS._load(res.json()["items"])
+        return self._LIST_CLASS._load(res.json()["items"], cognite_client=self._cognite_client)
 
     def create(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.48.1"
+version = "0.48.2"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
As reported by @senickel on Slack: https://cognitedata.slack.com/archives/C010VCGKBCM/p1616056126005500

Bumping version to `0.48.2`