### PR TITLE
[MLOPS-738] Fix error messages for FunctionCallsAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## Unreleased
+
+### Fixed
+- Correct error message when specifying both `function_id` and `function_external_id` on methods `FunctionCallsAPI.list()`, `FunctionCallsAPI.retrieve()`, `FunctionCallsAPI.get_response()` and `FunctionCallsAPI.get_logs()`.
+
 ## [0.53.1]
 
 ### Fixed

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -497,8 +497,8 @@ def _assert_exactly_one_of_function_id_and_function_external_id(function_id, fun
     has_function_id = function_id is not None
     has_function_external_id = function_external_id is not None
 
-    assert (has_function_id or function_external_id) and not (
-        has_function_id and function_external_id
+    assert (has_function_id or has_function_external_id) and not (
+        has_function_id and has_function_external_id
     ), "Exactly one of function_id and function_external_id must be specified"
 
 

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -3,7 +3,7 @@ import os
 import sys
 import time
 from inspect import getsource
-from numbers import Number
+from numbers import Integral, Number
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Callable, Dict, List, Optional, Union
@@ -491,6 +491,17 @@ def _validate_function_handle(function_handle):
         )
 
 
+def _assert_exactly_one_of_function_id_and_function_external_id(function_id, function_external_id):
+    utils._auxiliary.assert_type(function_id, "function_id", [Integral], allow_none=True)
+    utils._auxiliary.assert_type(function_external_id, "function_external_id", [str], allow_none=True)
+    has_function_id = function_id is not None
+    has_function_external_id = function_external_id is not None
+
+    assert (has_function_id or function_external_id) and not (
+        has_function_id and function_external_id
+    ), "Exactly one of function_id and function_external_id must be specified"
+
+
 class FunctionCallsAPI(APIClient):
     _LIST_CLASS = FunctionCallList
 
@@ -534,7 +545,7 @@ class FunctionCallsAPI(APIClient):
                 >>> calls = func.list_calls()
 
         """
-        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        _assert_exactly_one_of_function_id_and_function_external_id(function_id, function_external_id)
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         filter = {"status": status, "scheduleId": schedule_id, "startTime": start_time, "endTime": end_time}
@@ -571,7 +582,7 @@ class FunctionCallsAPI(APIClient):
                 >>> call = func.retrieve_call(id=2)
 
         """
-        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        _assert_exactly_one_of_function_id_and_function_external_id(function_id, function_external_id)
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         resource_path = f"/functions/{function_id}/calls"
@@ -604,7 +615,7 @@ class FunctionCallsAPI(APIClient):
                 >>> response = call.get_response()
 
         """
-        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        _assert_exactly_one_of_function_id_and_function_external_id(function_id, function_external_id)
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls/{call_id}/response"
@@ -640,7 +651,7 @@ class FunctionCallsAPI(APIClient):
                 >>> logs = call.get_logs()
 
         """
-        utils._auxiliary.assert_exactly_one_of_id_or_external_id(function_id, function_external_id)
+        _assert_exactly_one_of_function_id_and_function_external_id(function_id, function_external_id)
         if function_external_id:
             function_id = self._cognite_client.functions.retrieve(external_id=function_external_id).id
         url = f"/functions/{function_id}/calls/{call_id}/logs"

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -720,6 +720,11 @@ class TestFunctionCallsAPI:
         assert isinstance(res, FunctionCallList)
         assert mock_function_calls_filter_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
 
+    def test_list_calls_with_function_id_and_function_external_id_raises(self):
+        with pytest.raises(AssertionError) as excinfo:
+            FUNCTION_CALLS_API.list(function_id=123, function_external_id="my-function")
+        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+
     def test_retrieve_call_by_function_id(self, mock_function_calls_retrieve_response):
         res = FUNCTION_CALLS_API.retrieve(call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCall)
@@ -731,6 +736,13 @@ class TestFunctionCallsAPI:
         assert isinstance(res, FunctionCall)
         assert mock_function_calls_retrieve_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
+    def test_retrieve_call_with_function_id_and_function_external_id_raises(self):
+        with pytest.raises(AssertionError) as excinfo:
+            FUNCTION_CALLS_API.retrieve(
+                call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
+            )
+        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
+
     def test_function_call_logs_by_function_id(self, mock_function_call_logs_response):
         res = FUNCTION_CALLS_API.get_logs(call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, FunctionCallLog)
@@ -741,6 +753,13 @@ class TestFunctionCallsAPI:
         res = FUNCTION_CALLS_API.get_logs(call_id=CALL_ID, function_external_id=f"func-no-{FUNCTION_ID}")
         assert isinstance(res, FunctionCallLog)
         assert mock_function_call_logs_response.calls[1].response.json()["items"] == res.dump(camel_case=True)
+
+    def test_function_call_logs_by_function_id_and_function_external_id_raises(self, mock_function_call_logs_response):
+        with pytest.raises(AssertionError) as excinfo:
+            FUNCTION_CALLS_API.get_logs(
+                call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
+            )
+        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
 
     @pytest.mark.usefixtures("mock_function_calls_retrieve_response")
     def test_get_logs_on_retrieved_call_object(self, mock_function_call_logs_response):
@@ -774,6 +793,13 @@ class TestFunctionCallsAPI:
         res = FUNCTION_CALLS_API.get_response(call_id=CALL_ID, function_id=FUNCTION_ID)
         assert isinstance(res, dict)
         assert mock_function_call_response_response.calls[0].response.json()["response"] == res
+
+    def test_function_call_response_by_function_id_and_function_external_id_raises(self):
+        with pytest.raises(AssertionError) as excinfo:
+            FUNCTION_CALLS_API.get_response(
+                call_id=CALL_ID, function_id=FUNCTION_ID, function_external_id=f"func-no-{FUNCTION_ID}"
+            )
+        assert "Exactly one of function_id and function_external_id must be specified" in str(excinfo.value)
 
     @pytest.mark.usefixtures("mock_function_calls_retrieve_response")
     def test_get_response_on_retrieved_call_object(self, mock_function_call_response_response):


### PR DESCRIPTION
The previous error message was
```
Exactly one of id and external_id must be specified
```
but should be
```
"Exactly one of function_id and function_external_id must be specified"
```