### PR TITLE
[MLOPS-736] Require function_id when creating schedule with OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Changes are grouped as follows
 ## [0.54.0]
 
 ### Changed
-- `FunctionSchedulesAPI.create` now requires `function_id` to be used when creating a schedule with OIDC through `client_credentials`. NB: The argument `function_external_id` has now changed position, necessitated by the fact that it now is an optional argument.
+- `FunctionSchedulesAPI.create` now requires `function_id` to be used when creating a schedule with OIDC through `client_credentials`.
+- `FunctionSchedulesAPI.create`: The arguments `function_id` and `function_external_id` are both optional and mutually exclusive.
+- `FunctionSchedulesAPI.create`: The argument `function_external_id` has changed position, necessitated by the fact that it is now optional.
 
 ### Fixed
 - Correct error message when specifying both `function_id` and `function_external_id` on methods `FunctionCallsAPI.list()`, `FunctionCallsAPI.retrieve()`, `FunctionCallsAPI.get_response()` and `FunctionCallsAPI.get_logs()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## Unreleased
+## [0.54.0]
+
+### Changed
+- `FunctionSchedulesAPI.create` now requires `function_id` to be used when creating a schedule with OIDC through `client_credentials`.
 
 ### Fixed
 - Correct error message when specifying both `function_id` and `function_external_id` on methods `FunctionCallsAPI.list()`, `FunctionCallsAPI.retrieve()`, `FunctionCallsAPI.get_response()` and `FunctionCallsAPI.get_logs()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Changes are grouped as follows
 ## [0.54.0]
 
 ### Changed
-- `FunctionSchedulesAPI.create` now requires `function_id` to be used when creating a schedule with OIDC through `client_credentials`.
+- `FunctionSchedulesAPI.create` now requires `function_id` to be used when creating a schedule with OIDC through `client_credentials`. NB: The argument `function_external_id` has now changed position, necessitated by the fact that it now is an optional argument.
 
 ### Fixed
 - Correct error message when specifying both `function_id` and `function_external_id` on methods `FunctionCallsAPI.list()`, `FunctionCallsAPI.retrieve()`, `FunctionCallsAPI.get_response()` and `FunctionCallsAPI.get_logs()`.

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -737,8 +737,9 @@ class FunctionSchedulesAPI(APIClient):
     def create(
         self,
         name: str,
-        function_external_id: str,
         cron_expression: str,
+        function_id: Optional[int] = None,
+        function_external_id: Optional[str] = None,
         client_credentials: Optional[Dict] = None,
         description: str = "",
         data: Optional[Dict] = None,
@@ -747,7 +748,8 @@ class FunctionSchedulesAPI(APIClient):
 
         Args:
             name (str): Name of the schedule.
-            function_external_id (str): External id of the function.
+            function_id (optional, int): Id of the function. This is required if the schedule is created with client_credentials.
+            function_external_id (optional, str): External id of the function. This is deprecated and cannot be used together with client_credentials.
             description (str): Description of the schedule.
             cron_expression (str): Cron expression.
             client_credentials: (optional, Dict): Dictionary containing client credentials:
@@ -766,14 +768,17 @@ class FunctionSchedulesAPI(APIClient):
                 >>> c = CogniteClient()
                 >>> schedule = c.functions.schedules.create(
                     name= "My schedule",
-                    function_external_id="my-external-id",
+                    function_id=123,
                     cron_expression="*/5 * * * *",
                     client_credentials={"client_id": "...", "client_secret": "..."},
                     description="This schedule does magic stuff.")
 
         """
+        _assert_exactly_one_of_function_id_and_function_external_id(function_id, function_external_id)
+
         nonce = None
         if client_credentials:
+            assert function_id is not None, "function_id must be set when creating a schedule with client_credentials."
             nonce = _use_client_credentials(self._cognite_client, client_credentials)
 
         body = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.53.2"
+version = "0.54.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
Must be merged after [this PR](https://github.com/cognitedata/context-api/pull/1924).