### PR TITLE
Add support for transformations and schedules

### DIFF
--- a/cognite/experimental/_api/transformation_schedules.py
+++ b/cognite/experimental/_api/transformation_schedules.py
@@ -1,0 +1,134 @@
+import json as _json
+from typing import List, Optional, Union
+
+from cognite.client import CogniteClient, utils
+from cognite.client._api_client import APIClient
+from requests import Response
+
+from cognite.experimental._constants import HANDLER_FILE_NAME, LIST_LIMIT_CEILING, LIST_LIMIT_DEFAULT, MAX_RETRIES
+from cognite.experimental.data_classes import (
+    OidcCredentials,
+    Transformation,
+    TransformationDestination,
+    TransformationJobBlockade,
+    TransformationList,
+    TransformationSchedule,
+    TransformationScheduleList,
+)
+from cognite.experimental.data_classes.transformations import TransformationFilter
+
+
+class TransformationSchedulesAPI(APIClient):
+    _RESOURCE_PATH = "/transformations/schedules"
+    _LIST_CLASS = TransformationScheduleList
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def create(
+        self, schedule: Union[TransformationSchedule, List[TransformationSchedule]]
+    ) -> Union[TransformationSchedule, TransformationScheduleList]:
+        """`Schedule the specified transformation with the specified configuration(s). <https://docs.cognite.com/api/playground/#operation/scheduleTransformations>`_
+
+        Args:
+            schedule (Union[TransformationSchedule, List[TransformationSchedule]]) – Configuration or list of configurations of the schedules to create.
+
+        Returns:
+            Created schedule(s)
+
+        Examples:
+
+            Create new schedules:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.experimental.data_classes import Transfromation
+                >>> c = CogniteClient()
+                >>> schedules = [TransformationSchedule(name="transformation1"), TransformationSchedule(name="transformation2")]
+                >>> res = c.transformations.schedule(schedules)
+        """
+        utils._auxiliary.assert_type(schedule, "schedule", [TransformationSchedule, list])
+        return self._create_multiple(schedule)
+
+    def list(self, include_public: bool = True, limit: Optional[int] = LIST_LIMIT_DEFAULT,) -> TransformationList:
+        """`List all transformation schedules. <https://docs.cognite.com/api/playground/#operation/transformationSchedules>`_
+
+        Args:
+            include_public (bool): Whether public transformations should be included in the results. (default true).
+            cursor (str): Cursor for paging through results.
+            limit (int): Limits the number of results to be returned. The maximum is 1000, default limit is 25.
+
+        Returns:
+            TransformationList: List of transformations
+
+        Example:
+
+            List transformations::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> transformations_list = c.transformations.list()
+        """
+        if limit in [float("inf"), -1, None]:
+            limit = LIST_LIMIT_CEILING
+
+        filter = TransformationFilter(include_public=include_public).dump(camel_case=True)
+
+        return self._list(method="GET", limit=limit, filter=filter,)
+
+    def delete(
+        self,
+        id: Union[int, List[int]] = None,
+        external_id: Union[str, List[str]] = None,
+        ignore_unknown_ids: bool = False,
+    ) -> None:
+        """`Unsubscribe one or more schedules <https://doc.cognitedata.com/api/playground/#operation/deleteSchedules>`_
+
+        Args:
+            id (Union[int, List[int]): Id or list of ids
+            external_id (Union[str, List[str]]): External ID or list of exgernal ids
+            ignore_unknown_ids (bool): Ignore IDs and external IDs that are not found rather than throw an exception.
+
+        Returns:
+            None
+
+        Examples:
+
+            Delete schedules by id or external id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> c.transformations.schedules.delete(id=[1,2,3], external_id="3")
+        """
+        self._delete_multiple(
+            ids=id, external_ids=external_id, wrap_ids=True, extra_body_fields={"ignoreUnknownIds": ignore_unknown_ids},
+        )
+
+    def _do_request(self, method: str, url_path: str, **kwargs) -> Response:
+        is_retryable, full_url = self._resolve_url(method, url_path)
+
+        json_payload = kwargs.get("json")
+        headers = self._configure_headers(self._config.headers.copy())
+        headers.update(kwargs.get("headers") or {})
+
+        if json_payload:
+            data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default)
+            kwargs["data"] = data
+
+        kwargs["headers"] = headers
+
+        # requests will by default follow redirects. This can be an SSRF-hazard if
+        # the client can be tricked to request something with an open redirect, in
+        # addition to leaking the token, as requests will send the headers to the
+        # redirected-to endpoint.
+        # If redirects are to be followed in a call, this should be opted into instead.
+        kwargs.setdefault("allow_redirects", False)
+
+        if is_retryable:
+            res = self._http_client_with_retry.request(method=method, url=full_url, **kwargs)
+        else:
+            res = self._http_client.request(method=method, url=full_url, **kwargs)
+
+        if not self._status_ok(res.status_code):
+            self._raise_API_error(res, payload=json_payload)
+        self._log_request(res, payload=json_payload)
+        return res

--- a/cognite/experimental/_api/transformations.py
+++ b/cognite/experimental/_api/transformations.py
@@ -1,31 +1,13 @@
-import importlib.util
 import json as _json
-import os
-import sys
-import time
-from inspect import getsource
-from numbers import Integral, Number
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Callable, Dict, List, Optional, Union
-from zipfile import ZipFile
+from typing import List, Optional, Union
 
-from cognite.client import CogniteClient, utils
+from cognite.client import utils
 from cognite.client._api_client import APIClient
-from cognite.client.data_classes import TimestampRange
-from cognite.client.exceptions import CogniteAPIError
 from requests import Response
 
 from cognite.experimental._api.transformation_schedules import TransformationSchedulesAPI
 from cognite.experimental._constants import HANDLER_FILE_NAME, LIST_LIMIT_CEILING, LIST_LIMIT_DEFAULT, MAX_RETRIES
-from cognite.experimental.data_classes import (
-    OidcCredentials,
-    Transformation,
-    TransformationDestination,
-    TransformationJobBlockade,
-    TransformationList,
-)
-from cognite.experimental.data_classes.transformation_schedules import TransformationSchedule
+from cognite.experimental.data_classes import Transformation, TransformationList
 from cognite.experimental.data_classes.transformations import TransformationFilter
 
 

--- a/cognite/experimental/_api/transformations.py
+++ b/cognite/experimental/_api/transformations.py
@@ -1,0 +1,167 @@
+import importlib.util
+import json as _json
+import os
+import sys
+import time
+from inspect import getsource
+from numbers import Integral, Number
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Callable, Dict, List, Optional, Union
+from zipfile import ZipFile
+
+from cognite.client import CogniteClient, utils
+from cognite.client._api_client import APIClient
+from cognite.client.data_classes import TimestampRange
+from cognite.client.exceptions import CogniteAPIError
+from requests import Response
+
+from cognite.experimental._api.transformation_schedules import TransformationSchedulesAPI
+from cognite.experimental._constants import HANDLER_FILE_NAME, LIST_LIMIT_CEILING, LIST_LIMIT_DEFAULT, MAX_RETRIES
+from cognite.experimental.data_classes import (
+    OidcCredentials,
+    Transformation,
+    TransformationDestination,
+    TransformationJobBlockade,
+    TransformationList,
+)
+from cognite.experimental.data_classes.transformation_schedules import TransformationSchedule
+from cognite.experimental.data_classes.transformations import TransformationFilter
+
+
+class TransformationsAPI(APIClient):
+    _RESOURCE_PATH = "/transformations"
+    _LIST_CLASS = TransformationList
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # self.jobs = TransformationJobsAPI(*args, **kwargs)
+        self.schedules = TransformationSchedulesAPI(*args, **kwargs)
+        # self.notifications = TransformationNotificationsAPI(*args, **kwargs)
+
+    def create(
+        self, transformation: Union[Transformation, List[Transformation]]
+    ) -> Union[Transformation, TransformationList]:
+        """`Create one or more transformations. <https://docs.cognite.com/api/playground/#operation/createTransformations>`_
+
+        Args:
+            transformation (Union[Transformation, List[Transformation]]) – Transformation or list of transformations to create.
+
+        Returns:
+            Created transformation(s)
+
+        Examples:
+
+            Create new transformations:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> from cognite.experimental.data_classes import Transfromation
+                >>> c = CogniteClient()
+                >>> transformations = [Transformation(name="transformation1"), Transformation(name="transformation2")]
+                >>> res = c.transformations.create(transformations)
+        """
+        utils._auxiliary.assert_type(transformation, "transformation", [Transformation, list])
+        return self._create_multiple(transformation)
+
+    def delete(self, id: Union[int, List[int]] = None, external_id: Union[str, List[str]] = None) -> None:
+        """`Delete one or more transformations. <https://docs.cognite.com/api/playground/#operation/deleteTransformations>`_
+
+        Args:
+            id (Union[int, List[int]): Id or list of ids.
+            external_id (Union[str, List[str]]): External ID or list of external ids.
+
+        Returns:
+            None
+
+        Example:
+
+            Delete transformations by id or external id::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> c.transformations.delete(id=[1,2,3], external_id="function3")
+        """
+        self._delete_multiple(ids=id, external_ids=external_id, wrap_ids=True)
+
+    def list(self, include_public: bool = True, limit: Optional[int] = LIST_LIMIT_DEFAULT,) -> TransformationList:
+        """`List all transformations. <https://docs.cognite.com/api/playground/#operation/transformations>`_
+
+        Args:
+            include_public (bool): Whether public transformations should be included in the results. (default true).
+            cursor (str): Cursor for paging through results.
+            limit (int): Limits the number of results to be returned. The maximum is 1000, default limit is 25.
+
+        Returns:
+            TransformationList: List of transformations
+
+        Example:
+
+            List transformations::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> transformations_list = c.transformations.list()
+        """
+        if limit in [float("inf"), -1, None]:
+            limit = LIST_LIMIT_CEILING
+
+        filter = TransformationFilter(include_public=include_public).dump(camel_case=True)
+
+        return self._list(method="GET", limit=limit, filter=filter,)
+
+    def retrieve(self, id: Optional[int] = None, external_id: Optional[str] = None) -> Optional[Transformation]:
+        """`Retrieve a single transformation by id. <https://docs.cognite.com/api/playground/#operation/getTransformation>`_
+
+        Args:
+            id (int, optional): ID
+            external_id (str, optional): External ID
+
+        Returns:
+            Optional[Transformation]: Requested transformation or None if it does not exist.
+
+        Examples:
+
+            Get transformation by id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.transformations.retrieve(id=1)
+
+            Get transformation by external id:
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> res = c.transformations.retrieve(external_id="1")
+        """
+        utils._auxiliary.assert_exactly_one_of_id_or_external_id(id, external_id)
+        return self._retrieve_multiple(ids=id, external_ids=external_id, wrap_ids=True)
+
+    def _do_request(self, method: str, url_path: str, **kwargs) -> Response:
+        is_retryable, full_url = self._resolve_url(method, url_path)
+
+        json_payload = kwargs.get("json")
+        headers = self._configure_headers(self._config.headers.copy())
+        headers.update(kwargs.get("headers") or {})
+
+        if json_payload:
+            data = _json.dumps(json_payload, default=utils._auxiliary.json_dump_default)
+            kwargs["data"] = data
+
+        kwargs["headers"] = headers
+
+        # requests will by default follow redirects. This can be an SSRF-hazard if
+        # the client can be tricked to request something with an open redirect, in
+        # addition to leaking the token, as requests will send the headers to the
+        # redirected-to endpoint.
+        # If redirects are to be followed in a call, this should be opted into instead.
+        kwargs.setdefault("allow_redirects", False)
+
+        if is_retryable:
+            res = self._http_client_with_retry.request(method=method, url=full_url, **kwargs)
+        else:
+            res = self._http_client.request(method=method, url=full_url, **kwargs)
+
+        if not self._status_ok(res.status_code):
+            self._raise_API_error(res, payload=json_payload)
+        self._log_request(res, payload=json_payload)
+        return res

--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -17,6 +17,7 @@ from cognite.experimental._api.plot_extraction import PlotDataExtractionAPI
 from cognite.experimental._api.pnid_object_detection import PNIDObjectDetectionAPI
 from cognite.experimental._api.pnid_parsing import DiagramsAPI, PNIDParsingAPI
 from cognite.experimental._api.templatecompletion import ExperimentalTemplatesAPI
+from cognite.experimental._api.transformations import TransformationsAPI
 from cognite.experimental._api.types import TypesAPI
 
 APIClient.RETRYABLE_POST_ENDPOINTS |= {
@@ -112,6 +113,8 @@ class CogniteClient(Client):
         self.extraction_pipeline_runs = ExtractionPipelinesRunsAPI(
             self._config, api_version="playground", cognite_client=self
         )
+
+        self.transformations = TransformationsAPI(self._config, api_version="playground", cognite_client=self)
 
         self.diagrams = DiagramsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         # template completion only

--- a/cognite/experimental/data_classes/__init__.py
+++ b/cognite/experimental/data_classes/__init__.py
@@ -4,4 +4,6 @@ from cognite.experimental.data_classes.contextualization import *
 from cognite.experimental.data_classes.extractionpipelineruns import *
 from cognite.experimental.data_classes.extractionpipelines import *
 from cognite.experimental.data_classes.functions import *
+from cognite.experimental.data_classes.transformation_schedules import *
+from cognite.experimental.data_classes.transformations import *
 from cognite.experimental.data_classes.types import *

--- a/cognite/experimental/data_classes/transformation_schedules.py
+++ b/cognite/experimental/data_classes/transformation_schedules.py
@@ -1,0 +1,47 @@
+from cognite.client.data_classes._base import *
+
+
+class TransformationSchedule(CogniteResource):
+    """The transformation schedules resource allows running recurrent transformations.
+
+    Args:
+        request_scheduler_id: Id of the schedule in request scheduler service.
+        id (int): Transformation id.
+        external_id (str): Transformation externalId.
+        created_at (int): Time when the schedule was created.
+        interval (str): Cron expression describes when the function should be called. Use http://www.cronmaker.com to create a cron expression.
+        is_paused (bool): If true, the transformation is not scheduled.
+        config_id (int): Transformation id for backward compatibility.
+        cognite_client (CogniteClient): The client to associate with this object.
+    """
+
+    def __init__(
+        self,
+        request_scheduler_id: int = None,
+        id: int = None,
+        external_id: str = None,
+        created_at: int = None,
+        interval: str = None,
+        is_paused: bool = None,
+        cognite_client=None,
+    ):
+        self.request_scheduler_id = request_scheduler_id
+        self.id = id
+        self.external_id = external_id
+        self.created_at = created_at
+        self.interval = interval
+        self.is_paused = is_paused
+        self.cognite_client = cognite_client
+
+    @classmethod
+    def _load(cls, resource: Union[Dict, str], cognite_client=None):
+        instance = super(TransformationSchedule, cls)._load(resource, cognite_client)
+        return instance
+
+    def __hash__(self):
+        return hash(self.request_scheduler_id)
+
+
+class TransformationScheduleList(CogniteResourceList):
+    _RESOURCE = TransformationSchedule
+    _ASSERT_CLASSES = False

--- a/cognite/experimental/data_classes/transformations.py
+++ b/cognite/experimental/data_classes/transformations.py
@@ -1,0 +1,238 @@
+from cognite.client.data_classes._base import *
+
+
+class TransformationDestination:
+    def __init__(self, type: str = None):
+        self.type = type
+
+
+class RawTable(TransformationDestination):
+    def __init__(self, type: str = None, raw_type: str = None, database: str = None, table: str = None):
+        super().__init__(type=type)
+        self.rawType = raw_type
+        self.database = database
+        self.table = table
+
+
+class _RawTableFactory:
+    def __call__(self, database: str = None, table: str = None):
+        return RawTable(type="raw_table", raw_type="plain_raw", database=database, table=table)
+
+
+TransformationDestination.assets = TransformationDestination("assets")
+TransformationDestination.timeseries = TransformationDestination("timeseries")
+TransformationDestination.asset_hierarchy = TransformationDestination("asset_hierarchy")
+TransformationDestination.Events = TransformationDestination("events")
+TransformationDestination.Datapoints = TransformationDestination("datapoints")
+TransformationDestination.StringDatapoints = TransformationDestination("string_datapoints")
+TransformationDestination.Sequences = TransformationDestination("sequences")
+TransformationDestination.Files = TransformationDestination("files")
+TransformationDestination.Labels = TransformationDestination("labels")
+TransformationDestination.Relationships = TransformationDestination("relationships")
+TransformationDestination.Raw = _RawTableFactory()
+
+
+class OidcCredentials:
+    def __init__(
+        self,
+        client_id: str = None,
+        client_secret: str = None,
+        scopes: str = None,
+        token_uri: str = None,
+        cdf_project_name: str = None,
+    ):
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.scopes = scopes
+        self.token_uri = token_uri
+        self.cdf_project_name = cdf_project_name
+
+
+class TransformationJobBlockade:
+    def __init__(self, reason: str = None, time: Optional[int] = None):
+        self.reason = reason
+        self.time = time
+
+
+class Transformation(CogniteResource):
+    """The transformations resource allows transforming data in CDF.
+
+    Args:
+        id (int): A server-generated ID for the object.
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+        name (str): The name of the ExtractionPipeline.
+        description (str): The description of the ExtractionPipeline.
+        data_set_id (int): The id of the dataset this ExtractionPipeline related with.
+        raw_tables (List[Dict[str, str]): list of raw tables in list format: [{"dbName": "value", "tableName" : "value"}].
+        last_success (int): Milliseconds value of last success status.
+        last_failure (int): Milliseconds value of last failure status.
+        last_message (str): Message of last failure.
+        last_seen (int): Milliseconds value of last seen status.
+        schedule (str): undefined/triggered/streamed/cron regex.
+        contacts (List[Dict[str, Any]]): list of contacts [{"name": "value", "email": "value", "role": "value", "sendNotification": boolean},...]
+        metadata (Dict[str, str]): Custom, application specific metadata. String key -> String value. Limits: Maximum length of key is 128 bytes, value 10240 bytes, up to 256 key-value pairs, of total size at most 10240.
+        source (str): Source text value for ExtractionPipeline.
+        documentation (str): Documentation text value for ExtractionPipeline.
+        created_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        last_updated_time (int): The number of milliseconds since 00:00:00 Thursday, 1 January 1970, Coordinated Universal Time (UTC), minus leap seconds.
+        created_by (str): ExtractionPipeline creator, usually email.
+        skip_notifications_in_minutes (int): Number value for system to skip sending email notification in minutes after last sending.
+        cognite_client (CogniteClient): The client to associate with this object.
+    """
+
+    def __init__(
+        self,
+        id: int = None,
+        external_id: str = None,
+        name: str = None,
+        query: str = None,
+        destination: TransformationDestination = None,
+        conflict_mode: str = None,
+        is_public: bool = True,
+        ignore_null_fields: bool = False,
+        source_api_key: str = None,
+        destination_api_key: str = None,
+        source_oidc_credentials: Optional[OidcCredentials] = None,
+        destination_oidc_credentials: Optional[OidcCredentials] = None,
+        created_time: Optional[int] = None,
+        last_updated_time: Optional[int] = None,
+        owner: str = None,
+        owner_is_current_user: bool = True,
+        has_source_api_key: Optional[bool] = None,
+        has_destination_api_key: Optional[bool] = None,
+        has_source_oidc_credentials: Optional[bool] = None,
+        has_destination_oidc_credentials: Optional[bool] = None,
+        cognite_client=None,
+    ):
+        self.id = id
+        self.external_id = external_id
+        self.name = name
+        self.query = query
+        self.destination = destination
+        self.conflict_mode = conflict_mode
+        self.is_public = is_public
+        self.ignore_null_fields = ignore_null_fields
+        self.source_api_key = source_api_key
+        self.has_source_api_key = has_source_api_key or source_api_key is not None
+        self.destination_api_key = destination_api_key
+        self.has_destination_api_key = has_destination_api_key or destination_api_key is not None
+        self.source_oidc_credentials = source_oidc_credentials
+        self.has_source_oidc_credentials = has_source_oidc_credentials or source_oidc_credentials is not None
+        self.destination_oidc_credentials = destination_oidc_credentials
+        self.has_destination_oidc_credentials = (
+            has_destination_oidc_credentials or destination_oidc_credentials is not None
+        )
+        self.created_time = created_time
+        self.last_updated_time = last_updated_time
+        self.owner = owner
+        self.owner_is_current_user = owner_is_current_user
+        self._cognite_client = cognite_client
+
+    @classmethod
+    def _load(cls, resource: Union[Dict, str], cognite_client=None):
+        instance = super(Transformation, cls)._load(resource, cognite_client)
+        if isinstance(instance.destination, Dict):
+            snake_dict = {utils._auxiliary.to_snake_case(key): value for (key, value) in instance.destination.items()}
+            if instance.destination.get("type") == "raw_table":
+                instance.destination = RawTable(**snake_dict)
+            else:
+                instance.destination = TransformationDestination(**snake_dict)
+        return instance
+
+    def __hash__(self):
+        return hash(self.external_id)
+
+
+class TransformationUpdate(CogniteUpdate):
+    """Changes applied to ExtractionPipeline
+
+    Args:
+        id (int): A server-generated ID for the object.
+        external_id (str): The external ID provided by the client. Must be unique for the resource type.
+    """
+
+    class _PrimitiveExtractionPipelineUpdate(CognitePrimitiveUpdate):
+        def set(self, value: Any) -> "TransformationUpdate":
+            return self._set(value)
+
+    class _ObjectExtractionPipelineUpdate(CogniteObjectUpdate):
+        def set(self, value: Dict) -> "TransformationUpdate":
+            return self._set(value)
+
+        def add(self, value: Dict) -> "TransformationUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "TransformationUpdate":
+            return self._remove(value)
+
+    class _ListExtractionPipelineUpdate(CogniteListUpdate):
+        def set(self, value: List) -> "TransformationUpdate":
+            return self._set(value)
+
+        def add(self, value: List) -> "TransformationUpdate":
+            return self._add(value)
+
+        def remove(self, value: List) -> "TransformationUpdate":
+            return self._remove(value)
+
+    @property
+    def external_id(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "externalId")
+
+    @property
+    def name(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "name")
+
+    @property
+    def description(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "description")
+
+    @property
+    def data_set_id(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "dataSetId")
+
+    @property
+    def raw_tables(self):
+        return TransformationUpdate._ListExtractionPipelineUpdate(self, "rawTables")
+
+    @property
+    def metadata(self):
+        return TransformationUpdate._ObjectExtractionPipelineUpdate(self, "metadata")
+
+    @property
+    def source(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "source")
+
+    @property
+    def documentation(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "documentation")
+
+    @property
+    def schedule(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "schedule")
+
+    @property
+    def contacts(self):
+        return TransformationUpdate._ListExtractionPipelineUpdate(self, "contacts")
+
+    @property
+    def skip_notifications_in_minutes(self):
+        return TransformationUpdate._PrimitiveExtractionPipelineUpdate(self, "skipNotificationsInMinutes")
+
+
+class TransformationList(CogniteResourceList):
+    _RESOURCE = Transformation
+    _UPDATE = TransformationUpdate
+
+
+class TransformationFilter(CogniteFilter):
+    """No description.
+
+    Args:
+        include_public (bool): Whether public transformations should be included in the results. The default is true.
+    """
+
+    def __init__(self, include_public: bool = True, cursor: str = None):
+        self.include_public = include_public
+        self.cursor = cursor

--- a/tests/tests_integration/test_api/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations.py
@@ -1,0 +1,34 @@
+import time
+from unittest import mock
+
+import pytest
+from cognite.client import utils
+from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
+
+from cognite.experimental import CogniteClient
+from cognite.experimental.data_classes import Transformation
+from cognite.experimental.data_classes.transformations import TransformationDestination
+from tests.utils import set_request_limit
+
+COGNITE_CLIENT = CogniteClient()
+
+
+@pytest.fixture
+def new_transformation():
+    transform = Transformation(name="any", destination=TransformationDestination.Raw("", ""))
+    ts = COGNITE_CLIENT.transformations.create(transform)
+
+    yield ts
+
+    COGNITE_CLIENT.transformations.delete(id=ts.id)
+    assert COGNITE_CLIENT.transformations.retrieve(ts.id) is None
+
+
+class TestTransformationsAPI:
+    def test_create(self, new_transformation):
+        assert (
+            new_transformation.name == "any"
+            and new_transformation.destination.type == "raw_table"
+            and new_transformation.destination.rawType == "plain_raw"
+            and new_transformation.id is not None
+        )

--- a/tests/tests_integration/test_api/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations.py
@@ -32,3 +32,11 @@ class TestTransformationsAPI:
             and new_transformation.destination.rawType == "plain_raw"
             and new_transformation.id is not None
         )
+
+    def test_retrieve(self, new_transformation):
+        retrieved_transformation = COGNITE_CLIENT.transformations.retrieve(new_transformation.id)
+        assert (
+            new_transformation.name == retrieved_transformation.name
+            and new_transformation.destination.type == retrieved_transformation.destination.type
+            and new_transformation.id == retrieved_transformation.id
+        )

--- a/tests/tests_integration/test_api/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations.py
@@ -1,14 +1,8 @@
-import time
-from unittest import mock
-
 import pytest
-from cognite.client import utils
-from cognite.client.exceptions import CogniteAPIError, CogniteNotFoundError
 
 from cognite.experimental import CogniteClient
 from cognite.experimental.data_classes import Transformation
 from cognite.experimental.data_classes.transformations import TransformationDestination
-from tests.utils import set_request_limit
 
 COGNITE_CLIENT = CogniteClient()
 

--- a/tests/tests_integration/test_api/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations.py
@@ -40,3 +40,7 @@ class TestTransformationsAPI:
             and new_transformation.destination.type == retrieved_transformation.destination.type
             and new_transformation.id == retrieved_transformation.id
         )
+
+    def test_list(self, new_transformation):
+        retrieved_transformations = COGNITE_CLIENT.transformations.list()
+        assert new_transformation.id in [transformation.id for transformation in retrieved_transformations]


### PR DESCRIPTION
created two new api endpoints `client.transformations` and `client.transformations.schedules`, as well as supporting classes and tests.