### PR TITLE
[MLOPS-739] Modify default values of cpu and memory for Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Changes are grouped as follows
 ## [0.59.1]
 
 ### Changed
-- In `FunctionSchedulesAPI.create`, the default value of `cpu` is changed from `0.25` to `None`, thus deferring the default value to the API, which also is `0.25`. The `cpu` keyword cannot be used for functions deployed in Azure.
-- In `FunctionSchedulesAPI.create`, the default value of `memory` is changed from `1.0` to `None`, thus deferring the default value to the API, which also is `1.0`. The `memory` keyword cannot be used for functions deployed in Azure.
+- In `FunctionsAPI.create`, the default value of `cpu` is changed from `0.25` to `None`, thus deferring the default value to the API, which also is `0.25`. The `cpu` keyword cannot be used for functions deployed in Azure.
+- In `FunctionsAPI.create`, the default value of `memory` is changed from `1.0` to `None`, thus deferring the default value to the API, which also is `1.0`. The `memory` keyword cannot be used for functions deployed in Azure.
 
 ## [0.59]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.59.1]
+
+### Changed
+- In `FunctionSchedulesAPI.create`, the default value of `cpu` is changed from `0.25` to `None`, thus deferring the default value to the API, which also is `0.25`. The `cpu` keyword cannot be used for functions deployed in Azure.
+- In `FunctionSchedulesAPI.create`, the default value of `memory` is changed from `1.0` to `None`, thus deferring the default value to the API, which also is `1.0`. The `memory` keyword cannot be used for functions deployed in Azure.
+
 ## [0.59]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ Changes are grouped as follows
 ## [0.59.1]
 
 ### Changed
-- In `FunctionsAPI.create`, the default value of `cpu` is changed from `0.25` to `None`, thus deferring the default value to the API, which also is `0.25`. The `cpu` keyword cannot be used for functions deployed in Azure.
-- In `FunctionsAPI.create`, the default value of `memory` is changed from `1.0` to `None`, thus deferring the default value to the API, which also is `1.0`. The `memory` keyword cannot be used for functions deployed in Azure.
+- In `FunctionsAPI.create`, the default value of `cpu` is changed from `0.25` to `None`, thus deferring the default value to the API, which also is `0.25`. The argument is unavailable in Azure.
+- In `FunctionsAPI.create`, the default value of `memory` is changed from `1.0` to `None`, thus deferring the default value to the API, which also is `1.0`. The argument is unavailable in Azure.
 
 ## [0.59]
 

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -50,8 +50,8 @@ class FunctionsAPI(APIClient):
         api_key: Optional[str] = None,
         secrets: Optional[Dict] = None,
         env_vars: Optional[Dict] = None,
-        cpu: Number = 0.25,
-        memory: Number = 1.0,
+        cpu: Optional[Number] = None,
+        memory: Optional[Number] = None,
     ) -> Function:
         """`When creating a function, <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions>`_
         the source code can be specified in one of three ways:\n
@@ -79,8 +79,8 @@ class FunctionsAPI(APIClient):
             api_key (str, optional):                API key that can be used inside the function to access data in CDF.
             secrets (Dict[str, str]):               Additional secrets as key/value pairs. These can e.g. password to simulators or other data sources. Keys must be lowercase characters, numbers or dashes (-) and at most 15 characters. You can create at most 5 secrets, all keys must be unique, and cannot be apikey.
             env_vars (Dict[str, str]):              Environment variables as key/value pairs. Keys can contain only letters, numbers or the underscore character. You can create at most 20 environment variables.
-            cpu (Number):                           Number of CPU cores per function. Defaults to 0.25. Allowed values are in the range [0.1, 0.6].
-            memory (Number):                        Memory per function measured in GB. Defaults to 1. Allowed values are in the range [0.1, 2.5].
+            cpu (Number, optional):                 Number of CPU cores per function. Allowed values are in the range [0.1, 0.6], and None translates to the API default which is 0.25 in GCP. The argument is unavailable in Azure.
+            memory (Number, optional):              Memory per function measured in GB. Allowed values are in the range [0.1, 2.5], and None translates to the API default which is 1 GB in GCP. The argument is unavailable in Azure.
 
         Returns:
             Function: The created function.
@@ -134,10 +134,12 @@ class FunctionsAPI(APIClient):
             "owner": owner,
             "fileId": file_id,
             "functionPath": function_path,
-            "cpu": float(cpu),
-            "memory": float(memory),
             "envVars": env_vars,
         }
+        if cpu:
+            function.update({"cpu": cpu})
+        if memory:
+            function.update({"memory": memory})
         if external_id:
             function.update({"externalId": external_id})
         if api_key:

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -113,8 +113,8 @@ class FunctionsAPI(APIClient):
         elif function_handle:
             _validate_function_handle(function_handle)
             file_id = self._zip_and_upload_handle(function_handle, name)
-        utils._auxiliary.assert_type(cpu, "cpu", [Number], allow_none=False)
-        utils._auxiliary.assert_type(memory, "memory", [Number], allow_none=False)
+        utils._auxiliary.assert_type(cpu, "cpu", [Number], allow_none=True)
+        utils._auxiliary.assert_type(memory, "memory", [Number], allow_none=True)
 
         sleep_time = 1.0  # seconds
         for i in range(MAX_RETRIES):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.59.0"
+version = "0.59.1"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -376,17 +376,9 @@ class TestFunctionsAPI:
         assert isinstance(res, Function)
         assert mock_functions_create_response.calls[1].response.json()["items"][0] == res.dump(camel_case=True)
 
-    def test_create_with_cpu_none_raises(self, mock_functions_create_response):
-        with pytest.raises(TypeError):
-            FUNCTIONS_API.create(name="myfunction", file_id=1234, cpu=None)
-
     def test_create_with_cpu_not_float_raises(self, mock_functions_create_response):
         with pytest.raises(TypeError):
             FUNCTIONS_API.create(name="myfunction", file_id=1234, cpu="0.2")
-
-    def test_create_with_memory_none_raises(self, mock_functions_create_response):
-        with pytest.raises(TypeError):
-            FUNCTIONS_API.create(name="myfunction", file_id=1234, memory=None)
 
     def test_create_with_memory_not_float_raises(self, mock_functions_create_response):
         with pytest.raises(TypeError):


### PR DESCRIPTION
After we disallowed setting `cpu` and `memory` on Functions in Azure ([here](https://github.com/cognitedata/context-api/pull/2085)), creating a function with the SDK in Azure stopped working. This is because these keyword arguments have default values in the SDK, and so the API returns 400. Also, setting them to `None` does not help, since we don't allow `None` in the API either. 