### PR TITLE
remove unstructured

### DIFF
--- a/CONTEXTUALIZATION.md
+++ b/CONTEXTUALIZATION.md
@@ -193,7 +193,7 @@ svg_url = job.result['svgUrl']
 
 ## Entity Extraction
 
-The following methods are available for a project whitelisted for unstructured search, and only for file types supported in the search index. 
+The following methods are available for file types supported in the search index. 
 ```python
 job = client.entity_extraction.extract(entities=["23-VG-9102", "23-VG-1000-not-existing"], 
                                file_ids = [1234])

--- a/CONTEXTUALIZATION.md
+++ b/CONTEXTUALIZATION.md
@@ -193,7 +193,7 @@ svg_url = job.result['svgUrl']
 
 ## Entity Extraction
 
-The following methods are available for file types supported in the search index. 
+The following methods are available for file types supported in the search index.
 ```python
 job = client.entity_extraction.extract(entities=["23-VG-9102", "23-VG-1000-not-existing"], 
                                file_ids = [1234])

--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -21,8 +21,7 @@ from cognite.experimental._api.templatecompletion import ExperimentalTemplatesAP
 from cognite.experimental._api.transformations import TransformationsAPI
 from cognite.experimental._api.types import TypesAPI
 
-APIClient.RETRYABLE_POST_ENDPOINTS |= {
-}
+APIClient.RETRYABLE_POST_ENDPOINTS |= {}
 APIClient.RETRYABLE_POST_ENDPOINTS |= {
     f"/{api}/{endpoint}"
     for api in ["types", "labels", "functions", "templates"]

--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -22,8 +22,6 @@ from cognite.experimental._api.transformations import TransformationsAPI
 from cognite.experimental._api.types import TypesAPI
 
 APIClient.RETRYABLE_POST_ENDPOINTS |= {
-    "/files/unstructured/search",
-    "/files/unstructured/downloadlink/parsed",
 }
 APIClient.RETRYABLE_POST_ENDPOINTS |= {
     f"/{api}/{endpoint}"

--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -21,7 +21,6 @@ from cognite.experimental._api.templatecompletion import ExperimentalTemplatesAP
 from cognite.experimental._api.transformations import TransformationsAPI
 from cognite.experimental._api.types import TypesAPI
 
-APIClient.RETRYABLE_POST_ENDPOINTS |= {}
 APIClient.RETRYABLE_POST_ENDPOINTS |= {
     f"/{api}/{endpoint}"
     for api in ["types", "labels", "functions", "templates"]


### PR DESCRIPTION
cleaning up anything related with unstructured search. Mark that the endpoints are also deprecated and should no longer be encouraged to use: https://docs.cognite.com/api/playground/#operation/unstructuredSearchFiles