### PR TITLE
Remove unneeded raw_type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.60.12]
+
+### Changed
+- `TransformationDestination.raw()` now uses `type = 'raw'` istead of `'raw_table'` and doesn't use deprecated `raw_type` parameter.
+
 ## [0.60.11]
 
 ### Added

--- a/cognite/experimental/data_classes/transformation_jobs.py
+++ b/cognite/experimental/data_classes/transformation_jobs.py
@@ -182,7 +182,7 @@ class TransformationJob(CogniteResource):
         instance = super(TransformationJob, cls)._load(resource, cognite_client)
         if isinstance(instance.destination, Dict):
             snake_dict = {utils._auxiliary.to_snake_case(key): value for (key, value) in instance.destination.items()}
-            if instance.destination.get("type") == "raw_table":
+            if instance.destination.get("type") == "raw":
                 instance.destination = RawTable(**snake_dict)
             else:
                 instance.destination = TransformationDestination(**snake_dict)

--- a/cognite/experimental/data_classes/transformations.py
+++ b/cognite/experimental/data_classes/transformations.py
@@ -13,6 +13,12 @@ class TransformationDestination:
     def __init__(self, type: str = None):
         self.type = type
 
+    def __hash__(self):
+        return hash(self.type)
+
+    def __eq__(self, obj):
+        return isinstance(obj, TransformationDestination) and hash(obj) == hash(self)
+
     @staticmethod
     def assets():
         """To be used when the transformation is meant to produce assets."""
@@ -74,15 +80,20 @@ class TransformationDestination:
         Returns:
             TransformationDestination pointing to the target table
         """
-        return RawTable(type="raw_table", raw_type="plain_raw", database=database, table=table)
+        return RawTable(type="raw", database=database, table=table)
 
 
 class RawTable(TransformationDestination):
-    def __init__(self, type: str = None, raw_type: str = None, database: str = None, table: str = None):
+    def __init__(self, type: str = None, database: str = None, table: str = None):
         super().__init__(type=type)
-        self.rawType = raw_type
         self.database = database
         self.table = table
+
+    def __hash__(self):
+        return hash((self.type, self.database, self.table))
+
+    def __eq__(self, obj):
+        return isinstance(obj, RawTable) and hash(obj) == hash(self)
 
 
 class OidcCredentials:
@@ -199,7 +210,7 @@ class Transformation(CogniteResource):
         instance = super(Transformation, cls)._load(resource, cognite_client)
         if isinstance(instance.destination, Dict):
             snake_dict = {utils._auxiliary.to_snake_case(key): value for (key, value) in instance.destination.items()}
-            if instance.destination.get("type") == "raw_table":
+            if instance.destination.get("type") == "raw":
                 instance.destination = RawTable(**snake_dict)
             else:
                 instance.destination = TransformationDestination(**snake_dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.60.11"
+version = "0.60.12"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_integration/test_api/test_transformations.py
+++ b/tests/tests_integration/test_api/test_transformations.py
@@ -29,6 +29,12 @@ class TestTransformationsAPI:
         ts = COGNITE_CLIENT.transformations.create(transform)
         COGNITE_CLIENT.transformations.delete(id=ts.id)
 
+    def test_create_raw_transformation(self):
+        transform = Transformation(name="any", destination=TransformationDestination.raw("myDatabase", "myTable"))
+        ts = COGNITE_CLIENT.transformations.create(transform)
+        COGNITE_CLIENT.transformations.delete(id=ts.id)
+        assert ts.destination == TransformationDestination.raw("myDatabase", "myTable")
+
     def test_create_asset_hierarchy_transformation(self):
         transform = Transformation(name="any", destination=TransformationDestination.asset_hierarchy())
         ts = COGNITE_CLIENT.transformations.create(transform)
@@ -42,7 +48,7 @@ class TestTransformationsAPI:
     def test_create(self, new_transformation):
         assert (
             new_transformation.name == "any"
-            and new_transformation.destination.type == "assets"
+            and new_transformation.destination == TransformationDestination.assets()
             and new_transformation.id is not None
         )
 
@@ -50,7 +56,7 @@ class TestTransformationsAPI:
         retrieved_transformation = COGNITE_CLIENT.transformations.retrieve(new_transformation.id)
         assert (
             new_transformation.name == retrieved_transformation.name
-            and new_transformation.destination.type == retrieved_transformation.destination.type
+            and new_transformation.destination == retrieved_transformation.destination
             and new_transformation.id == retrieved_transformation.id
         )
 


### PR DESCRIPTION
`TransformationDestination.raw()` now uses `type = 'raw'` istead of `'raw_table'` and doesn't use deprecated `raw_type` parameter.