### PR TITLE
fix data classes to string circular reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.60.22]
+
+### Fixed
+- `str(TransformationJobMetric)`, `str(TransformationJob)`, `str(TransformationNotification)` and `str(TransformationSchedule)` no longer throw an exception.
+
 ## [0.60.21]
 
 ### Added

--- a/cognite/experimental/data_classes/transformation_jobs.py
+++ b/cognite/experimental/data_classes/transformation_jobs.py
@@ -31,7 +31,7 @@ class TransformationJobMetric(CogniteResource):
         self.timestamp = timestamp
         self.name = name
         self.count = count
-        self.cognite_client = cognite_client
+        self._cognite_client = cognite_client
 
     @classmethod
     def _load(cls, resource: Union[Dict, str], cognite_client=None):
@@ -102,11 +102,11 @@ class TransformationJob(CogniteResource):
         self.started_time = started_time
         self.finished_time = finished_time
         self.last_seen_time = last_seen_time
-        self.cognite_client = cognite_client
+        self._cognite_client = cognite_client
 
     def update(self):
         """`Get updated job status. <https://docs.cognite.com/api/playground/#operation/runTransformation>`_"""
-        updated = self.cognite_client.transformations.jobs.retrieve(id=self.id)
+        updated = self._cognite_client.transformations.jobs.retrieve(id=self.id)
         self.status = updated.status
         self.error = updated.error
         self.started_time = updated.started_time
@@ -115,7 +115,7 @@ class TransformationJob(CogniteResource):
 
     def metrics(self):
         """`Get job metrics. <https://docs.cognite.com/api/playground/#operation/runTransformation>`_"""
-        return self.cognite_client.transformations.jobs.list_metrics(self.id)
+        return self._cognite_client.transformations.jobs.list_metrics(self.id)
 
     def wait(self, polling_interval: float = 1, timeout: Optional[float] = None) -> "TransformationJob":
         """`Waits for the job to finish.`_

--- a/cognite/experimental/data_classes/transformation_notifications.py
+++ b/cognite/experimental/data_classes/transformation_notifications.py
@@ -30,7 +30,7 @@ class TransformationNotification(CogniteResource):
         self.destination = destination
         self.created_time = created_time
         self.last_updated_time = last_updated_time
-        self.cognite_client = cognite_client
+        self._cognite_client = cognite_client
 
     @classmethod
     def _load(cls, resource: Union[Dict, str], cognite_client=None):

--- a/cognite/experimental/data_classes/transformation_schedules.py
+++ b/cognite/experimental/data_classes/transformation_schedules.py
@@ -30,7 +30,7 @@ class TransformationSchedule(CogniteResource):
         self.last_updated_time = last_updated_time
         self.interval = interval
         self.is_paused = is_paused
-        self.cognite_client = cognite_client
+        self._cognite_client = cognite_client
 
     @classmethod
     def _load(cls, resource: Union[Dict, str], cognite_client=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.60.21"
+version = "0.60.22"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/tests/tests_integration/test_api/test_transformation_jobs.py
+++ b/tests/tests_integration/test_api/test_transformation_jobs.py
@@ -131,7 +131,7 @@ class TestTransformationJobsAPI:
         job = longer_transformation.run(timeout=timeout)
         final = time.time()
 
-        assert job.status == TransformationJobStatus.RUNNING and timeout <= final - init <= timeout + 1
+        assert job.status == TransformationJobStatus.RUNNING and timeout <= final - init <= timeout + 1.5
 
     @pytest.mark.asyncio
     async def test_run_async(self, new_transformation: Transformation):
@@ -158,7 +158,7 @@ class TestTransformationJobsAPI:
         job = await longer_transformation.run_async(timeout=timeout)
         final = time.time()
 
-        assert job.status == TransformationJobStatus.RUNNING and timeout <= final - init <= timeout + 1
+        assert job.status == TransformationJobStatus.RUNNING and timeout <= final - init <= timeout + 1.5
 
     @pytest.mark.asyncio
     async def test_run_by_external_id_async(self, new_transformation: Transformation):

--- a/tests/tests_integration/test_api/test_transformation_notifications.py
+++ b/tests/tests_integration/test_api/test_transformation_notifications.py
@@ -104,3 +104,6 @@ class TestTransformationNotificationsAPI:
         )
         assert new_notification.id in [notification.id for notification in retrieved_notifications]
         assert len(retrieved_notifications) == 1
+
+    def test_notification_to_string(self, new_notification):
+        dumped = str(new_notification)


### PR DESCRIPTION
many transformation data classes defined `cls.cognite_client` instead of `cls._cognite_client`. This caused a circular reference exception when dumping them to json on `str(cls)`