### PR TITLE
Change from actual import to AST parse

### DIFF
--- a/cognite/experimental/_constants.py
+++ b/cognite/experimental/_constants.py
@@ -3,3 +3,4 @@ LIST_LIMIT_DEFAULT = 25
 LIST_LIMIT_CEILING = 10_000  # variable used to guarantee all items are returned when list(limit) is None, inf or -1.
 HANDLER_FILE_NAME = "handler.py"
 MAX_RETRIES = 5
+HANDLE_ARGS = {"data", "client", "secrets", "function_call_info"}

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -323,12 +323,12 @@ class TestFunctionsAPI:
         [
             (".", "handler.py", None),
             ("function_code", "./handler.py", None),
-            ("bad_function_code", "handler.py", TypeError),
+            ("bad_function_code", "handler.py", FileNotFoundError),
             ("bad_function_code2", "handler.py", TypeError),
             ("./good_absolute_import/", "my_functions/handler.py", None),
-            ("bad_absolute_import", "extra_root_folder/my_functions/handler.py", ModuleNotFoundError),
+            # ("bad_absolute_import", "extra_root_folder/my_functions/handler.py", ModuleNotFoundError),  # TODO: Good?
             ("relative_imports", "my_functions/good_relative_import.py", None),
-            ("relative_imports", "bad_relative_import.py", ImportError),
+            # ("relative_imports", "bad_relative_import.py", ImportError),  # TODO: Good?
         ],
     )
     def test_validate_folder(self, function_folder, function_path, exception):


### PR DESCRIPTION
# Proposal [in the making]
Currently, the experimental SDK for function deployment of directories (of code) does an actual python import to verify its "importability" and code validity, like the `handler.py`, the `handle` function and its arguments. If you just want to deploy some code, without having all of the dependencies installed, it will fail during this trial-import-stage with for instance, "numpy was not found" (or "my random data science package"). A very typical example of this is in a CI/CD pipeline like those using the `function-action(-oidc)` or similar. 

What I propose instead, is to parse the AST of the file and verify the function (handle) + arguments.

Downside:
Without doing an actual import, you lose the check that verifies that the import statements are correct / working.

...to which I'd argue that anyone pushing a directory of code probably has worked on it locally and tested it to be working before they wanted to run it in the cloud.

Very interested to hear your thoughts on the matter 😄  This could significantly reduce the code and complexity of the two Github actions, since they rely on zipping and uploading directly to files, to circumvent this check.