### PR TITLE
point transformations to v1 api

### DIFF
--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -112,7 +112,7 @@ class CogniteClient(Client):
             self._config, api_version="playground", cognite_client=self
         )
 
-        self.transformations = TransformationsAPI(self._config, api_version="playground", cognite_client=self)
+        self.transformations = TransformationsAPI(self._config, api_version="v1", cognite_client=self)
 
         self.diagrams = DiagramsAPI(self._config, api_version=self._API_VERSION, cognite_client=self)
         # template completion only


### PR DESCRIPTION
transformations api is now avalable in v1, so playground users will use that version now