### PR TITLE
[MLOPS-264] Functions: Overwrite file in filesAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.60.37]
+
+### Changed
+- When creating a function with `function_handle` or `folder` and with `external_id` specified, the zip file uploaded to the Files API is given an external-id and is overwritten if it already exists.
+
 ## [0.60.36]
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.60.36"
+version = "0.60.37"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
When creating a function with `function_handle` or `folder` and with `external_id` specified, the zip file uploaded to the Files API is given an external-id and is overwritten if it already exists.