### PR TITLE
Skip geospatial tests for now until configuration is ready

### DIFF
--- a/tests/tests_integration/test_api/test_geospatial.py
+++ b/tests/tests_integration/test_api/test_geospatial.py
@@ -181,6 +181,7 @@ def clean_old_custom_crs():
         pass
 
 
+@pytest.mark.skip(reason="Configuration is missing on greenfield python-sdk-test project")
 class TestGeospatialAPI:
     def test_create_features(self, test_feature_type, allow_crs_transformation):
         external_id = f"F_{uuid.uuid4().hex[:10]}"


### PR DESCRIPTION
Skipping the geospatial tests for now since the configuration on the greenfield `python-sdk-test` project is missing the necessary configuration at this moment.