### PR TITLE
Add support to specify metadata when creating a function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ### Added
 
-- Optional argument `metadata` to `FunctionsAPI.create` which allows metadata in the form of key:value pairs to be added to each function.
+- Optional argument `metadata` to `FunctionsAPI.create` which allows metadata in the form of key:value pairs of strings to be added to each function.
 
 ## [0.68.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.68.4]
+
+### Added
+
+- Optional argument `metadata` to `FunctionsAPI.create` which allows metadata in the form of key:value pairs to be added to each function.
+
 ## [0.68.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [0.68.4]
+## [0.69.0]
 
 ### Added
 

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -54,6 +54,7 @@ class FunctionsAPI(APIClient):
         cpu: Optional[Number] = None,
         memory: Optional[Number] = None,
         runtime: Optional[str] = None,
+        metadata: Optional[Dict] = None,
     ) -> Function:
         """`When creating a function, <https://docs.cognite.com/api/playground/#operation/post-api-playground-projects-project-functions>`_
         the source code can be specified in one of three ways:\n
@@ -82,6 +83,7 @@ class FunctionsAPI(APIClient):
             cpu (Number, optional):                 Number of CPU cores per function. Allowed values are in the range [0.1, 0.6], and None translates to the API default which is 0.25 in GCP. The argument is unavailable in Azure.
             memory (Number, optional):              Memory per function measured in GB. Allowed values are in the range [0.1, 2.5], and None translates to the API default which is 1 GB in GCP. The argument is unavailable in Azure.
             runtime (str, optional):                The function runtime. Valid values are ["py37", "py38", "py39", `None`], and `None` translates to the API default which currently is "py38". The runtime "py3x" resolves to the latest version of the Python 3.x.y series.
+            metadata (Dict[str, str], optional):    Metadata for the function as key/value pairs. Key & values can be at most 32, 512 characters long respectively. You can have at the most 16 key-value pairs, with a maximum size of 512 bytes.
 
         Returns:
             Function: The created function.
@@ -149,6 +151,8 @@ class FunctionsAPI(APIClient):
             function["apiKey"] = api_key
         if secrets:
             function["secrets"] = secrets
+        if metadata:
+            function["metadata"] = metadata
         body = {"items": [function]}
         res = self._post(url, json=body)
         return Function._load(res.json()["items"][0], cognite_client=self._cognite_client)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -138,6 +138,7 @@ class FunctionsAPI(APIClient):
             "fileId": file_id,
             "functionPath": function_path,
             "envVars": env_vars,
+            "metadata": metadata,
         }
         if cpu:
             function["cpu"] = cpu
@@ -151,8 +152,6 @@ class FunctionsAPI(APIClient):
             function["apiKey"] = api_key
         if secrets:
             function["secrets"] = secrets
-        if metadata:
-            function["metadata"] = metadata
         body = {"items": [function]}
         res = self._post(url, json=body)
         return Function._load(res.json()["items"][0], cognite_client=self._cognite_client)

--- a/cognite/experimental/data_classes/functions.py
+++ b/cognite/experimental/data_classes/functions.py
@@ -27,6 +27,7 @@ class Function(CogniteResource):
         cpu (Number): Number of CPU cores per function. Defaults to 0.25. Allowed values are in the range [0.1, 0.6].
         memory (Number): Memory per function measured in GB. Defaults to 1. Allowed values are in the range [0.1, 2.5].
         runtime (str): Runtime of the function. Allowed values are ["py37", "py38", "py39"]. The runtime "py3x" resolves to the latest version of the Python 3.x.y series. Will default to "py38" if not specified.
+        metadata(Dict[str, str): Metadata associated with a function as a set of key:value pairs.
         error(Dict[str, str]): Dictionary with keys "message" and "trace", which is populated if deployment fails.
         cognite_client (CogniteClient): An optional CogniteClient to associate with this data class.
     """
@@ -48,6 +49,7 @@ class Function(CogniteResource):
         cpu: Number = None,
         memory: Number = None,
         runtime: str = None,
+        metadata: Dict = None,
         error: Dict = None,
         cognite_client=None,
     ):
@@ -66,6 +68,7 @@ class Function(CogniteResource):
         self.cpu = cpu
         self.memory = memory
         self.runtime = runtime
+        self.metadata = metadata
         self.error = error
         self._cognite_client = cognite_client
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.68.4"
+version = "0.69.0"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
-version = "0.68.3"
+version = "0.68.4"
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
 


### PR DESCRIPTION
* Add optional argument metadata to FunctionsAPI.create()

* Update pyproject.toml
