### PR TITLE
mlops-1075 Switch auth api over to v1 from playgrounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Changes are grouped as follows
 
 ### Changed
 
-- Use v1 sessions api instead of the playground endpoint.
+- Use `v1` sessions endpoint instead of `playground` in functions api.
 
 ## [0.74.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.74.1]
+
+### Changed
+
+- Use v1 sessions api instead of the playground endpoint.
+
 ## [0.74.0]
 
 ### Added

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -434,7 +434,7 @@ def _use_client_credentials(cognite_client: CogniteClient, client_credentials: O
         client_id = cognite_client.config.token_client_id
         client_secret = cognite_client.config.token_client_secret
 
-    session_url = f"/api/playground/projects/{cognite_client.config.project}/sessions"
+    session_url = f"/api/V1/projects/{cognite_client.config.project}/sessions"
     payload = {"items": [{"clientId": client_id, "clientSecret": client_secret}]}
     try:
         res = cognite_client.post(session_url, json=payload)
@@ -445,7 +445,7 @@ def _use_client_credentials(cognite_client: CogniteClient, client_credentials: O
 
 
 def _use_token_exchange(cognite_client: CogniteClient) -> str:
-    session_url = f"/api/playground/projects/{cognite_client.config.project}/sessions"
+    session_url = f"/api/V1/projects/{cognite_client.config.project}/sessions"
     payload = {"items": [{"tokenExchange": True}]}
     try:
         res = cognite_client.post(url=session_url, json=payload)

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -434,7 +434,7 @@ def _use_client_credentials(cognite_client: CogniteClient, client_credentials: O
         client_id = cognite_client.config.token_client_id
         client_secret = cognite_client.config.token_client_secret
 
-    session_url = f"/api/V1/projects/{cognite_client.config.project}/sessions"
+    session_url = f"/api/v1/projects/{cognite_client.config.project}/sessions"
     payload = {"items": [{"clientId": client_id, "clientSecret": client_secret}]}
     try:
         res = cognite_client.post(session_url, json=payload)
@@ -445,7 +445,7 @@ def _use_client_credentials(cognite_client: CogniteClient, client_credentials: O
 
 
 def _use_token_exchange(cognite_client: CogniteClient) -> str:
-    session_url = f"/api/V1/projects/{cognite_client.config.project}/sessions"
+    session_url = f"/api/v1/projects/{cognite_client.config.project}/sessions"
     payload = {"items": [{"tokenExchange": True}]}
     try:
         res = cognite_client.post(url=session_url, json=payload)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.74.0"
+version = "0.74.1"
 
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -665,6 +665,7 @@ def mock_function_schedules_response(rsps):
 @pytest.fixture
 def mock_function_schedules_response_oidc_client_credentials(rsps):
     session_url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
+    session_url = session_url.replace("playground", "v1")
     rsps.add(
         rsps.POST,
         session_url,

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -109,6 +109,7 @@ CALL_SCHEDULED = {
 @pytest.fixture
 def mock_sessions_with_client_credentials(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
+    url = url.replace("playgrounds", "v1")
     rsps.add(
         rsps.POST,
         url=url,
@@ -134,6 +135,7 @@ def mock_sessions_with_client_credentials(rsps):
 @pytest.fixture
 def mock_sessions_with_token_exchange(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
+    url = url.replace("playgrounds", "v1")
     rsps.add(
         rsps.POST,
         url=url,
@@ -229,6 +231,7 @@ def mock_functions_call_responses(rsps):
 @pytest.fixture
 def mock_sessions_bad_request_response(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
+    url = url.replace("playgrounds", "v1")
     rsps.add(rsps.POST, url, status=400)
 
     yield rsps

--- a/tests/tests_unit/test_api/test_functions.py
+++ b/tests/tests_unit/test_api/test_functions.py
@@ -109,7 +109,7 @@ CALL_SCHEDULED = {
 @pytest.fixture
 def mock_sessions_with_client_credentials(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
-    url = url.replace("playgrounds", "v1")
+    url = url.replace("playground", "v1")
     rsps.add(
         rsps.POST,
         url=url,
@@ -135,7 +135,7 @@ def mock_sessions_with_client_credentials(rsps):
 @pytest.fixture
 def mock_sessions_with_token_exchange(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
-    url = url.replace("playgrounds", "v1")
+    url = url.replace("playground", "v1")
     rsps.add(
         rsps.POST,
         url=url,
@@ -231,7 +231,7 @@ def mock_functions_call_responses(rsps):
 @pytest.fixture
 def mock_sessions_bad_request_response(rsps):
     url = FUNCTIONS_API._get_base_url_with_base_path() + "/sessions"
-    url = url.replace("playgrounds", "v1")
+    url = url.replace("playground", "v1")
     rsps.add(rsps.POST, url, status=400)
 
     yield rsps


### PR DESCRIPTION
Auth is removing the playgrounds endpoints in favour of v1 counterparts. 
This change is to use the new API endpoints in functions SDK