### PR TITLE
VIS-789: Filter annotations by data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.75.0]
+
+### Added
+
+- AnnotationsV2: Support for filtering the annotations data field
+
 ## [0.74.1]
 
 ### Changed

--- a/cognite/experimental/data_classes/annotations_v2.py
+++ b/cognite/experimental/data_classes/annotations_v2.py
@@ -125,6 +125,7 @@ class AnnotationV2Filter(CogniteFilter):
         linked_resource_type(str, optional): Type of the CDF resource the annotations to filter for are linked to, if any.
         linked_resource_ids(List[Dict[str, Any]], optional): List of ids or external ids the annotations are linked to. Example format: [{"id": 1234}, {"external_id": "ext_1234"}] .
         annotation_type(str, optional): Type name of the annotations.
+        data(Dict[str, Any], optional): The annotation data to filter by. Example format: {"label": "cat", "confidence": 0.9}
     """
 
     def __init__(
@@ -138,6 +139,7 @@ class AnnotationV2Filter(CogniteFilter):
         linked_resource_type: Optional[str] = None,
         linked_resource_ids: Optional[List[Dict[str, Any]]] = None,
         annotation_type: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.annotated_resource_type = annotated_resource_type
         self.annotated_resource_ids = annotated_resource_ids
@@ -148,6 +150,7 @@ class AnnotationV2Filter(CogniteFilter):
         self.linked_resource_type = linked_resource_type
         self.linked_resource_ids = linked_resource_ids
         self.annotation_type = annotation_type
+        self.data = data
 
     def dump(self, camel_case: bool = False):
         result = super(AnnotationV2Filter, self).dump(camel_case=camel_case)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.74.1"
+version = "0.75.0"
 
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]

--- a/tests/tests_integration/test_contextualization/test_annotations_v2.py
+++ b/tests/tests_integration/test_contextualization/test_annotations_v2.py
@@ -174,6 +174,24 @@ class TestAnnotationsV2Integration:
         _test_list_on_created_annotations(cognite_client, created_annotations_1, limit=-1)
         _test_list_on_created_annotations(cognite_client, created_annotations_2, limit=-1)
 
+    def test_list_with_data_filter(self, cognite_client: CogniteClient, base_annotation: AnnotationV2) -> None:
+        base_annotation.annotation_type = "images.Classification"
+        base_annotation.data = {"label": "test_0"}
+        created_annotation_0 = cognite_client.annotations_v2.create(base_annotation)
+        base_annotation.data = {"label": "test_1"}
+        created_annotation_1 = cognite_client.annotations_v2.create(base_annotation)
+
+        filtered_annotations = cognite_client.annotations_v2.list(
+            filter=AnnotationV2Filter(
+                annotated_resource_type="file",
+                annotated_resource_ids=[{"id": base_annotation.annotated_resource_id}],
+                data={"label": "test_1"},
+            )
+        )
+        assert isinstance(filtered_annotations, AnnotationV2List)
+        assert len(filtered_annotations) == 1
+        assert created_annotation_1.dump() == filtered_annotations[0].dump()
+
     def test_list_limit(self, cognite_client: CogniteClient, base_annotation: AnnotationV2) -> None:
         created_annotations = cognite_client.annotations_v2.create([base_annotation] * 30)
         _test_list_on_created_annotations(cognite_client, created_annotations, limit=5)


### PR DESCRIPTION
Adds the `data` field to AnnotationV2Filter in correspondance with the
recent changes to the AnnotationsV2 API that introduces support for
querying of the annotation data field.

## Checklist

- [x] Changelog entry added in `CHANGELOG` or not relevant for this change
- [x] Version updated in `pyproject.toml` or not relevant for this change
