### PR TITLE
Fix: Make prediction results serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.92.0]
+
+### Changed
+- Renamed Vision's annotate method to extract
+- Updated Vision data classes
+
+### Added
+- Method to save predictions made by Vision's extract method (previously called annotate) in CDF using the Annotations API
+- Method to retrieve a Vision feature extraction job by job id. 
+
 ## [0.91.1]
 
 ### Added

--- a/cognite/experimental/_api/vision.py
+++ b/cognite/experimental/_api/vision.py
@@ -97,6 +97,8 @@ class VisionAPI(ContextAPI):
                 >>> for item in extract_job.items:
                 ...     predictions = item.predictions
                 ...     # do something with the predictions
+                >>> # Save predictions in CDF using Annotations API:
+                >>> extract_job.save_predictions()
         """
         # Sanitize input(s)
         assert_type(features, "features", [Feature, list], allow_none=False)

--- a/cognite/experimental/_api/vision.py
+++ b/cognite/experimental/_api/vision.py
@@ -81,10 +81,10 @@ class VisionAPI(ContextAPI):
 
         Args:
             features (Union[Feature, List[Feature]]): The feature(s) to extract from the provided image files.
-            file_ids (List[int]): IDs of the image files to annotate. The images must already be uploaded in the same CDF project.
-            file_external_ids (List[str]): The external file ids of the image files to annotate
+            file_ids (List[int]): IDs of the image files to analyze. The images must already be uploaded in the same CDF project.
+            file_external_ids (List[str]): The external file ids of the image files to analyze.
         Returns:
-            VisionExtractJobResults: Resulting queued job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
+            VisionExtractJob: Resulting queued job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
 
         Examples:
             Start a job, wait for completion and then get the parsed results::
@@ -113,3 +113,31 @@ class VisionAPI(ContextAPI):
             features=features,
             job_cls=VisionExtractJob,
         )
+
+    def get_extract_job(self, job_id: InternalId) -> VisionExtractJob:
+        """Retrieve an extraction job.
+
+        Args:
+            job_id (InternalId): ID of an existing feature extraction job.
+        Returns:
+            VisionExtractJob: Vision  extract job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
+
+        Examples:
+            Retrieve a vision extract job by ID::
+
+                >>> from cognite.experimental import CogniteClient
+                >>> c = CogniteClient()
+                >>> extract_job = c.vision.get_extract_job(job_id=1)
+                >>> extract_job.wait_for_completion()
+                >>> for item in extract_job.items:
+                ...     predictions = item.predictions
+                ...     # do something with the predictions
+        """
+        job = VisionExtractJob(
+            job_id=job_id,
+            status_path=f"{self._RESOURCE_PATH}/annotate/",  # TODO: rename to extract
+            cognite_client=self._cognite_client,
+        )
+        job.update_status()
+
+        return job

--- a/cognite/experimental/_api/vision.py
+++ b/cognite/experimental/_api/vision.py
@@ -4,12 +4,12 @@ from cognite.client.utils._auxiliary import assert_type
 
 from cognite.experimental._context_client import ContextAPI
 from cognite.experimental.data_classes.vision import (
-    AnnotateJobResults,
     CreatedDetectAssetsInFilesJob,
     DetectAssetsInFilesJob,
     EitherFileId,
     Feature,
     InternalId,
+    VisionExtractJob,
 )
 from cognite.experimental.utils import resource_to_camel_case
 
@@ -71,20 +71,20 @@ class VisionAPI(ContextAPI):
         """
         return self._retrieve(id=job_id, resource_path=self._TAG_DETECTION_PATH, cls=DetectAssetsInFilesJob)
 
-    def annotate(
+    def extract(
         self,
         features: Union[Feature, List[Feature]],
         file_ids: Optional[List[int]] = None,
         file_external_ids: Optional[List[str]] = None,
-    ) -> AnnotateJobResults:
-        """Annotate image files with a provided set of feature(s).
+    ) -> VisionExtractJob:
+        """Extract features from image files.
 
         Args:
             features (Union[Feature, List[Feature]]): The feature(s) to extract from the provided image files.
             file_ids (List[int]): IDs of the image files to annotate. The images must already be uploaded in the same CDF project.
             file_external_ids (List[str]): The external file ids of the image files to annotate
         Returns:
-            AnnotateJobResults: Resulting queued job, which can be used to retrieve the status of the job or the annotation results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
+            VisionExtractJobResults: Resulting queued job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
 
         Examples:
             Start a job, wait for completion and then get the parsed results::
@@ -92,11 +92,11 @@ class VisionAPI(ContextAPI):
                 >>> from cognite.experimental import CogniteClient
                 >>> from cognite.experimental.data_classes.vision import Feature
                 >>> c = CogniteClient()
-                >>> annotate_job = c.vision.annotate(features=Feature.ASSET_TAG_DETECTION, file_ids=[1])
-                >>> annotate_job.wait_for_completion()
-                >>> for item in annotate_job.items:
-                ...     annotations = item.annotations
-                ...     # do something with the annotations
+                >>> extract_job = c.vision.extract(features=Feature.ASSET_TAG_DETECTION, file_ids=[1])
+                >>> extract_job.wait_for_completion()
+                >>> for item in extract_job.items:
+                ...     predictions = item.predictions
+                ...     # do something with the predictions
         """
         # Sanitize input(s)
         assert_type(features, "features", [Feature, list], allow_none=False)
@@ -107,9 +107,9 @@ class VisionAPI(ContextAPI):
             features = [features]
 
         return self._run_job(
-            job_path="/annotate",
-            status_path="/annotate/",
+            job_path="/annotate",  # TODO: rename to extract
+            status_path="/annotate/",  # TODO: rename to extract
             items=self._process_file_ids(file_ids, file_external_ids),
             features=features,
-            job_cls=AnnotateJobResults,
+            job_cls=VisionExtractJob,
         )

--- a/cognite/experimental/_api/vision.py
+++ b/cognite/experimental/_api/vision.py
@@ -122,7 +122,7 @@ class VisionAPI(ContextAPI):
         Args:
             job_id (InternalId): ID of an existing feature extraction job.
         Returns:
-            VisionExtractJob: Vision  extract job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
+            VisionExtractJob: Vision extract job, which can be used to retrieve the status of the job or the prediction results if the job is finished. Note that .result property of this job will wait for the job to finish and returns the results.
 
         Examples:
             Retrieve a vision extract job by ID::

--- a/cognite/experimental/_api/vision.py
+++ b/cognite/experimental/_api/vision.py
@@ -109,8 +109,8 @@ class VisionAPI(ContextAPI):
             features = [features]
 
         return self._run_job(
-            job_path="/annotate",  # TODO: rename to extract
-            status_path="/annotate/",  # TODO: rename to extract
+            job_path="/extract",
+            status_path="/extract/",
             items=self._process_file_ids(file_ids, file_external_ids),
             features=features,
             job_cls=VisionExtractJob,
@@ -137,7 +137,7 @@ class VisionAPI(ContextAPI):
         """
         job = VisionExtractJob(
             job_id=job_id,
-            status_path=f"{self._RESOURCE_PATH}/annotate/",  # TODO: rename to extract
+            status_path=f"{self._RESOURCE_PATH}/extract/",
             cognite_client=self._cognite_client,
         )
         job.update_status()

--- a/cognite/experimental/data_classes/annotation_types/images.py
+++ b/cognite/experimental/data_classes/annotation_types/images.py
@@ -1,11 +1,17 @@
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from cognite.experimental.data_classes.annotation_types.primitives import BoundingBox, CdfResourceRef, Polygon, PolyLine
+from cognite.experimental.data_classes.annotation_types.primitives import (
+    BoundingBox,
+    CdfResourceRef,
+    Polygon,
+    PolyLine,
+    VisionResource,
+)
 
 
 @dataclass
-class ObjectDetection:
+class ObjectDetection(VisionResource):
     label: str
     confidence: Optional[float]
     # A valid object detection instance needs to have *exactly one* of these
@@ -23,7 +29,7 @@ class ObjectDetection:
 
 
 @dataclass
-class TextRegion:
+class TextRegion(VisionResource):
     text: str
     text_region: BoundingBox
     confidence: Optional[float] = None
@@ -34,7 +40,7 @@ class TextRegion:
 
 
 @dataclass
-class AssetLink:
+class AssetLink(VisionResource):
     text: str
     text_region: BoundingBox
     asset_ref: CdfResourceRef

--- a/cognite/experimental/data_classes/annotation_types/images.py
+++ b/cognite/experimental/data_classes/annotation_types/images.py
@@ -50,4 +50,4 @@ class AssetLink(VisionResource):
         if isinstance(self.text_region, Dict):
             self.text_region = BoundingBox(**self.text_region)
         if isinstance(self.asset_ref, Dict):
-            self.text_region = CdfResourceRef(**self.asset_ref)
+            self.asset_ref = CdfResourceRef(**self.asset_ref)

--- a/cognite/experimental/data_classes/annotation_types/primitives.py
+++ b/cognite/experimental/data_classes/annotation_types/primitives.py
@@ -1,9 +1,53 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
+
+from cognite.client import utils
+from cognite.client.data_classes._base import EXCLUDE_VALUE
+
+
+class VisionResource:
+    def dump(self, camel_case: bool = False) -> Dict[str, Any]:
+        """Dump the instance into a json serializable Python data type.
+
+        Args:
+            camel_case (bool): Use camelCase for attribute names. Defaults to False.
+
+        Returns:
+            Dict[str, Any]: A dictionary representation of the instance.
+        """
+        return {
+            utils._auxiliary.to_camel_case(key)
+            if camel_case
+            else key: value.dump(camel_case=camel_case)
+            if hasattr(value, "dump")
+            else value
+            for key, value in self.__dict__.items()
+            if value not in EXCLUDE_VALUE and not key.startswith("_")
+        }
+
+    def to_pandas(self, camel_case: bool = False) -> Dict[str, Any]:
+        pd = utils._auxiliary.local_import("pandas")
+        df = pd.DataFrame(columns=["value"])
+
+        for key, value in self.__dict__.items():
+            if isinstance(value, list) and all(hasattr(v, "dump") for v in value):
+                df.loc[utils._auxiliary.to_camel_case(key) if camel_case else key] = [
+                    [v.dump(camel_case=camel_case) for v in value]
+                ]
+            if hasattr(value, "dump"):
+                df.loc[utils._auxiliary.to_camel_case(key) if camel_case else key] = [value.dump(camel_case=camel_case)]
+            else:
+                if value not in EXCLUDE_VALUE:
+                    df.loc[utils._auxiliary.to_camel_case(key) if camel_case else key] = [value]
+
+        return df
+
+    def _repr_html_(self):
+        return self.to_pandas(camel_case=False)._repr_html_()
 
 
 @dataclass
-class Point:
+class Point(VisionResource):
     x: float
     y: float
 
@@ -24,7 +68,7 @@ def _process_vertices(vertices: List[Union[PointDict, Point]]) -> List[Point]:
 
 
 @dataclass
-class BoundingBox:
+class BoundingBox(VisionResource):
     x_min: float
     x_max: float
     y_min: float
@@ -32,14 +76,14 @@ class BoundingBox:
 
 
 @dataclass
-class CdfResourceRef:
+class CdfResourceRef(VisionResource):
     # A valid reference instance contains exactly one of these
     id: Optional[int] = None
     external_id: Optional[str] = None
 
 
 @dataclass
-class Polygon:
+class Polygon(VisionResource):
     # A valid polygon contains *at least* three vertices
     vertices: List[Point]
 
@@ -48,7 +92,7 @@ class Polygon:
 
 
 @dataclass
-class PolyLine:
+class PolyLine(VisionResource):
     # A valid polyline contains *at least* two vertices
     vertices: List[Point]
 

--- a/cognite/experimental/data_classes/vision.py
+++ b/cognite/experimental/data_classes/vision.py
@@ -63,6 +63,15 @@ VISION_FEATURE_MAP: Dict[str, FeatureClass] = {
     for key, value in get_type_hints(VisionExtractPredictions).items()
 }
 
+
+VISION_ANNOTATION_TYPE_MAP: Dict[str, str] = {
+    "text_annotations": "images.TextRegion",
+    "asset_tag_annotations": "images.AssetLink",
+    "industrial_object_annotations": "images.ObjectDetection",
+    "people_annotations": "images.ObjectDetection",
+    "personal_protective_equipment_annotations": "images.ObjectDetection",
+}
+
 EitherFileId = Union[InternalFileId, ExternalFileId]
 
 
@@ -392,13 +401,7 @@ class VisionExtractJob(VisionJob):
         return [
             Annotation(
                 annotated_resource_id=item.file_id,
-                annotation_type=(
-                    "images.TextRegion"
-                    if annotation_type == "text_annotations"
-                    else "images.AssetLink"
-                    if annotation_type == "asset_tag_annotations"
-                    else "images.ObjectDetection"
-                ),
+                annotation_type=VISION_ANNOTATION_TYPE_MAP[annotation_type],
                 data=data.dump(),
                 annotated_resource_type="file",
                 status="suggested",

--- a/cognite/experimental/data_classes/vision.py
+++ b/cognite/experimental/data_classes/vision.py
@@ -382,7 +382,7 @@ class VisionExtractJob(VisionJob):
         """Returns a list of all error messages across files"""
         return [item["errorMessage"] for item in self.result["items"] if "errorMessage" in item]
 
-    def _represent_predictions_as_annotations(
+    def _predictions_to_annotations(
         self,
         creating_user: Optional[str] = None,
         creating_app: Optional[str] = None,
@@ -429,7 +429,7 @@ class VisionExtractJob(VisionJob):
             Union[Annotation, AnnotationList]: (suggested) annotation(s) stored in CDF.
 
         """
-        annotations = self._represent_predictions_as_annotations(
+        annotations = self._predictions_to_annotations(
             creating_user=creating_user, creating_app=creating_app, creating_app_version=creating_app_version
         )
         if annotations:

--- a/cognite/experimental/data_classes/vision.py
+++ b/cognite/experimental/data_classes/vision.py
@@ -418,7 +418,7 @@ class VisionExtractJob(VisionJob):
         creating_app_version: Optional[str] = None,
     ) -> Union[Annotation, AnnotationList]:
         """
-        Saves all predictions made by the feature extractors in CDF using Annotations API.
+        Saves all predictions made by the feature extractors in CDF using the Annotations API.
         See https://docs.cognite.com/api/v1/#tag/Annotations/operation/annotationsSuggest
 
         Args:

--- a/docs/source/cognite.rst
+++ b/docs/source/cognite.rst
@@ -383,9 +383,16 @@ Vision
 The Vision API enable extraction of information from imagery data based on
 their visual content. For example, you can can extract features such as text, asset tags or industrial objects from images using this service.
 
-Annotate
-^^^^^^^^^^^^^
-.. automethod:: cognite.experimental._api.vision.VisionAPI.annotate
+
+
+Extract
+^^^^^^^
+.. automethod:: cognite.experimental._api.vision.VisionAPI.extract
+
+
+Get vision extract job
+^^^^^^^^^^^^^^^^^^^^^^
+.. automethod:: cognite.experimental._api.vision.VisionAPI.get_extract_job
 
 Data classes
 ^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.91.1"
+version = "0.92.0"
 
 
 description = "Experimental additions to the Python SDK"

--- a/tests/tests_integration/test_vision/test_extract.py
+++ b/tests/tests_integration/test_vision/test_extract.py
@@ -3,7 +3,7 @@ from cognite.client.data_classes import FileMetadata
 from cognite.client.data_classes.contextualization import JobStatus
 
 from cognite.experimental import CogniteClient
-from cognite.experimental.data_classes.vision import AnnotateJobResults, Feature
+from cognite.experimental.data_classes.vision import Feature, VisionExtractJob
 
 COGNITE_CLIENT = CogniteClient()
 VAPI = COGNITE_CLIENT.vision
@@ -18,17 +18,17 @@ def cognite_client() -> CogniteClient:
 @pytest.fixture(scope="class")
 def file_id(cognite_client: CogniteClient) -> int:
     # Create a test file
-    name = "vision_annotate_test_file"
+    name = "vision_extract_test_file"
     file = cognite_client.files.create(FileMetadata(external_id=name, name=name), overwrite=True)[0]
     yield file.id
 
     cognite_client.files.delete(id=file.id)
 
 
-class TestAnnotate:
-    def test_annotate(self, file_id: int) -> None:
-        job = VAPI.annotate(features=Feature.PEOPLE_DETECTION, file_ids=[file_id])
-        assert isinstance(job, AnnotateJobResults)
+class TestExtract:
+    def test_extract(self, file_id: int) -> None:
+        job = VAPI.extract(features=Feature.PEOPLE_DETECTION, file_ids=[file_id])
+        assert isinstance(job, VisionExtractJob)
         assert job.job_id > 0
         assert JobStatus(job.status) == JobStatus.QUEUED
         assert len(job.items) == 1

--- a/tests/tests_unit/test_data_classes/test_vision.py
+++ b/tests/tests_unit/test_data_classes/test_vision.py
@@ -13,12 +13,12 @@ from cognite.experimental.data_classes.vision import VisionExtractItem, VisionEx
 from cognite.experimental.utils import resource_to_camel_case, resource_to_snake_case
 
 mock_vision_predictions_dict: Dict[str, Any] = {
-    "textAnnotations": [  # TODO: rename to predictions
+    "textPredictions": [
         {"text": "a", "textRegion": {"xMin": 0.1, "xMax": 0.2, "yMin": 0.3, "yMax": 0.4}, "confidence": 0.1}
     ]
 }
 mock_vision_extract_predictions = VisionExtractPredictions(
-    text_annotations=[  # TODO: rename to predictions
+    text_predictions=[
         TextRegion(
             text="a",
             text_region=BoundingBox(x_min=0.1, x_max=0.2, y_min=0.3, y_max=0.4),
@@ -92,7 +92,7 @@ class TestVisionResource:
             ),
             (
                 VisionExtractPredictions(
-                    text_annotations=[  # TODO: rename to predictions
+                    text_predictions=[
                         TextRegion(
                             text="foo",
                             text_region={"x_min": 0.1, "x_max": 0.1, "y_min": 0.1, "y_max": 0.1},
@@ -101,7 +101,7 @@ class TestVisionResource:
                     ]
                 ),
                 {
-                    "textAnnotations": [  # TODO: rename to predictions
+                    "textPredictions": [
                         {"text": "foo", "textRegion": {"xMin": 0.1, "xMax": 0.1, "yMin": 0.1, "yMax": 0.1}}
                     ]
                 },
@@ -131,11 +131,11 @@ class TestVisionExtractItem:
         "resource, expected_item",
         [
             (
-                {"fileId": 1, "fileExternalId": "a", "annotations": None},  # TODO: rename to predictions
+                {"fileId": 1, "fileExternalId": "a", "predictions": None},
                 VisionExtractItem(file_id=1, file_external_id="a", predictions=None),
             ),
             (
-                {"fileId": 1, "annotations": mock_vision_predictions_dict},
+                {"fileId": 1, "predictions": mock_vision_predictions_dict},
                 VisionExtractItem(file_id=1, predictions=mock_vision_predictions_dict),
             ),
         ],
@@ -158,8 +158,8 @@ class TestVisionExtractItem:
                 {
                     "fileId": 1,
                     "fileExternalId": "a",
-                    "annotations": resource_to_camel_case(mock_vision_predictions_dict),
-                },  # TODO: rename to predictions
+                    "predictions": resource_to_camel_case(mock_vision_predictions_dict),
+                },
                 True,
             ),
         ],
@@ -177,7 +177,7 @@ class TestVisionExtractJob:
             (JobStatus.QUEUED, None, None),
             (
                 JobStatus.COMPLETED,
-                {"items": [{"fileId": 1, "annotations": mock_vision_predictions_dict}]},  # TODO: rename to predictions
+                {"items": [{"fileId": 1, "predictions": mock_vision_predictions_dict}]},
                 [VisionExtractItem(file_id=1, predictions=mock_vision_predictions_dict)],
             ),
         ],
@@ -213,7 +213,7 @@ class TestVisionExtractJob:
                 {
                     "fileId": i + 1,
                     "fileExternalId": "foo",
-                    "annotations": mock_vision_predictions_dict,  # TODO: rename to predictions
+                    "predictions": mock_vision_predictions_dict,
                 }
                 for i in range(2)
             ]
@@ -235,23 +235,23 @@ class TestVisionExtractJob:
                 [],
             ),
             (
-                {"items": [{"fileId": 1, "annotations": {}}]},
+                {"items": [{"fileId": 1, "predictions": {}}]},
                 None,
                 [],
             ),
             (
-                {"items": [{"fileId": 1, "annotations": {"text_annotations": []}}]},
+                {"items": [{"fileId": 1, "predictions": {"text_predictions": []}}]},
                 None,
                 [],
             ),
             (
-                {"items": [{"fileId": 1, "annotations": mock_vision_predictions_dict}]},  # TODO: rename to predictions
+                {"items": [{"fileId": 1, "predictions": mock_vision_predictions_dict}]},
                 {"creating_user": None, "creating_app": None, "creating_app_version": None},
                 [
                     Annotation(
                         annotated_resource_id=1,
                         annotation_type="images.TextRegion",
-                        data=resource_to_snake_case(mock_vision_predictions_dict)["text_annotations"][0],
+                        data=resource_to_snake_case(mock_vision_predictions_dict)["text_predictions"][0],
                         annotated_resource_type="file",
                         status="suggested",
                         creating_app="cognite-sdk-experimental",
@@ -261,13 +261,13 @@ class TestVisionExtractJob:
                 ],
             ),
             (
-                {"items": [{"fileId": 1, "annotations": mock_vision_predictions_dict}]},  # TODO: rename to predictions
+                {"items": [{"fileId": 1, "predictions": mock_vision_predictions_dict}]},
                 {"creating_user": "foo", "creating_app": "bar", "creating_app_version": "1.0.0"},
                 [
                     Annotation(
                         annotated_resource_id=1,
                         annotation_type="images.TextRegion",
-                        data=resource_to_snake_case(mock_vision_predictions_dict)["text_annotations"][0],
+                        data=resource_to_snake_case(mock_vision_predictions_dict)["text_predictions"][0],
                         annotated_resource_type="file",
                         status="suggested",
                         creating_app="bar",
@@ -279,8 +279,8 @@ class TestVisionExtractJob:
         ],
         ids=[
             "empty_items",
-            "empty_annotations",
-            "empty_text_annotations",
+            "empty_predictions",
+            "empty_text_predictions",
             "completed_job_default_params",
             "completed_job_with_user_params",
         ],

--- a/tests/tests_unit/test_data_classes/test_vision.py
+++ b/tests/tests_unit/test_data_classes/test_vision.py
@@ -285,7 +285,7 @@ class TestVisionExtractJob:
             "completed_job_with_user_params",
         ],
     )
-    def test_represent_predictions_as_annotations(
+    def test_predictions_to_annotations(
         self,
         mock_result: MagicMock,
         result: Optional[Dict],
@@ -296,4 +296,4 @@ class TestVisionExtractJob:
         cognite_client.version = (params or {}).get("creating_app_version") or 1
         mock_result.return_value = result
         job = VisionExtractJob(status=JobStatus.COMPLETED.value, cognite_client=cognite_client)
-        assert job._represent_predictions_as_annotations(**(params or {})) == expected_items
+        assert job._predictions_to_annotations(**(params or {})) == expected_items

--- a/tests/tests_unit/test_vision/test_extract.py
+++ b/tests/tests_unit/test_vision/test_extract.py
@@ -1,14 +1,12 @@
-import json
 import re
 from typing import Any, Dict, List, Optional, Union
-from unittest.mock import MagicMock
 
 import pytest
 from cognite.client.data_classes.contextualization import JobStatus
 from responses import RequestsMock
 
 from cognite.experimental import CogniteClient
-from cognite.experimental.data_classes.vision import AnnotateJobResults, Feature
+from cognite.experimental.data_classes.vision import Feature, VisionExtractJob
 from tests.utils import jsgz_load
 
 COGNITE_CLIENT = CogniteClient()
@@ -44,7 +42,9 @@ def mock_get_response_body_ok() -> Dict[str, Any]:
         "items": [
             {
                 "fileId": 1,
-                "annotations": [{"text": "testing", "assetIds": [1, 2, 3], "confidence": 0.9}],
+                "annotations": [
+                    {"text": "testing", "assetIds": [1, 2, 3], "confidence": 0.9}
+                ],  # TODO: rename to predictions
             },
         ],
         "useCache": True,
@@ -54,10 +54,10 @@ def mock_get_response_body_ok() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def mock_post_annotate(rsps: RequestsMock, mock_post_response_body: Dict[str, Any]) -> RequestsMock:
+def mock_post_extract(rsps: RequestsMock, mock_post_response_body: Dict[str, Any]) -> RequestsMock:
     rsps.add(
         rsps.POST,
-        re.compile(".*?/context/vision/annotate"),
+        re.compile(".*?/context/vision/annotate"),  # TODO: rename to extract
         status=200,
         json=mock_post_response_body,
     )
@@ -65,10 +65,10 @@ def mock_post_annotate(rsps: RequestsMock, mock_post_response_body: Dict[str, An
 
 
 @pytest.fixture
-def mock_get_annotate(rsps: RequestsMock, mock_get_response_body_ok: Dict[str, Any]) -> RequestsMock:
+def mock_get_extract(rsps: RequestsMock, mock_get_response_body_ok: Dict[str, Any]) -> RequestsMock:
     rsps.add(
         rsps.GET,
-        re.compile(".*?/context/vision/annotate/\\d+"),
+        re.compile(".*?/context/vision/annotate/\\d+"),  # TODO: rename to extract
         status=200,
         json=mock_get_response_body_ok,
     )
@@ -93,10 +93,10 @@ class TestAnnotate:
             "multiple_features",
         ],
     )
-    def test_annotate(
+    def test_extract(
         self,
-        mock_post_annotate: RequestsMock,
-        mock_get_annotate: RequestsMock,
+        mock_post_extract: RequestsMock,
+        mock_get_extract: RequestsMock,
         features: Union[Feature, List[Feature]],
         error_message: Optional[str],
     ) -> None:
@@ -104,11 +104,12 @@ class TestAnnotate:
         file_external_ids = []
         if error_message is not None:
             with pytest.raises(TypeError, match=error_message):
-                VAPI.annotate(features=features, file_ids=file_ids, file_external_ids=file_external_ids)
+                VAPI.extract(features=features, file_ids=file_ids, file_external_ids=file_external_ids)
         else:
-            job = VAPI.annotate(features=features, file_ids=file_ids, file_external_ids=file_external_ids)
-            # Job should be queued immediately after a successfull POST
-            assert isinstance(job, AnnotateJobResults)
+            # Job should be queued immediately after a successfully POST
+            job = VAPI.extract(features=features, file_ids=file_ids, file_external_ids=file_external_ids)
+            # Job should be queued immediately after a successfully POST
+            assert isinstance(job, VisionExtractJob)
             assert "Queued" == job.status
             # Wait for job to complete and check its content
             expected_job_id = 1
@@ -118,8 +119,8 @@ class TestAnnotate:
             assert expected_job_id == job.job_id
 
             num_post_requests, num_get_requests = 0, 0
-            for call in mock_post_annotate.calls:
-                if "annotate" in call.request.url and call.request.method == "POST":
+            for call in mock_post_extract.calls:
+                if "annotate" in call.request.url and call.request.method == "POST":  # TODO: rename to extract
                     num_post_requests += 1
                     assert {
                         "features": [f.value for f in features] if isinstance(features, list) else [features.value],

--- a/tests/tests_unit/test_vision/test_extract.py
+++ b/tests/tests_unit/test_vision/test_extract.py
@@ -109,7 +109,6 @@ class TestExtract:
         else:
             # Job should be queued immediately after a successfully POST
             job = VAPI.extract(features=features, file_ids=file_ids, file_external_ids=file_external_ids)
-            # Job should be queued immediately after a successfully POST
             assert isinstance(job, VisionExtractJob)
             assert "Queued" == job.status
             # Wait for job to complete and check its content

--- a/tests/tests_unit/test_vision/test_extract.py
+++ b/tests/tests_unit/test_vision/test_extract.py
@@ -43,9 +43,7 @@ def mock_get_response_body_ok() -> Dict[str, Any]:
         "items": [
             {
                 "fileId": 1,
-                "annotations": [
-                    {"text": "testing", "assetIds": [1, 2, 3], "confidence": 0.9}
-                ],  # TODO: rename to predictions
+                "predictions": [{"text": "testing", "assetIds": [1, 2, 3], "confidence": 0.9}],
             },
         ],
         "useCache": True,
@@ -58,7 +56,7 @@ def mock_get_response_body_ok() -> Dict[str, Any]:
 def mock_post_extract(rsps: RequestsMock, mock_post_response_body: Dict[str, Any]) -> RequestsMock:
     rsps.add(
         rsps.POST,
-        re.compile(".*?/context/vision/annotate"),  # TODO: rename to extract
+        re.compile(".*?/context/vision/extract"),
         status=200,
         json=mock_post_response_body,
     )
@@ -69,7 +67,7 @@ def mock_post_extract(rsps: RequestsMock, mock_post_response_body: Dict[str, Any
 def mock_get_extract(rsps: RequestsMock, mock_get_response_body_ok: Dict[str, Any]) -> RequestsMock:
     rsps.add(
         rsps.GET,
-        re.compile(".*?/context/vision/annotate/\\d+"),  # TODO: rename to extract
+        re.compile(".*?/context/vision/extract/\\d+"),
         status=200,
         json=mock_get_response_body_ok,
     )
@@ -120,7 +118,7 @@ class TestExtract:
 
             num_post_requests, num_get_requests = 0, 0
             for call in mock_post_extract.calls:
-                if "annotate" in call.request.url and call.request.method == "POST":  # TODO: rename to extract
+                if "extract" in call.request.url and call.request.method == "POST":
                     num_post_requests += 1
                     assert {
                         "features": [f.value for f in features] if isinstance(features, list) else [features.value],
@@ -150,7 +148,7 @@ class TestExtract:
 
         num_get_requests = 0
         for call in mock_get_extract.calls:
-            if "annotate" in call.request.url and call.request.method == "GET":  # TODO: rename to extract
+            if "extract" in call.request.url and call.request.method == "GET":
                 num_get_requests += 1
                 assert f"/{job.job_id}" in call.request.url
         assert 1 == num_get_requests


### PR DESCRIPTION
Also rename `annotate` -> `extract` and `annotations` to `predictions`

## Checklist

- [x] Changelog entry added in `CHANGELOG` or not relevant for this change
- [x] Version updated in `pyproject.toml` or not relevant for this change
