### PR TITLE
Requirement.txt fix on function SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.93.1]
+
+### Fixed
+- Small error on requirements.txt parsing on functions SDK.
+
 ## [0.93.0]
 
 ### Added

--- a/cognite/experimental/_api/functions.py
+++ b/cognite/experimental/_api/functions.py
@@ -428,7 +428,8 @@ class FunctionsAPI(APIClient):
                 )
 
             return file.id
-
+        except Exception as e:
+            raise e
         finally:
             os.chdir(current_dir)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.93.0"
+version = "0.93.1"
 
 
 description = "Experimental additions to the Python SDK"


### PR DESCRIPTION
validate_requirements(reqs) function raises when there is requirement.txt parsing error but the error was consumed due to try finally block. Re-raising should fix it.

## Checklist

- [ x ] Changelog entry added in `CHANGELOG` or not relevant for this change
- [ x ] Version updated in `pyproject.toml` or not relevant for this change
