### PR TITLE
Fix deduplicated alert signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.108.2]
+
+### Fixed
+- Fixed create deduplicated alert function signature
+
 ## [0.108.1]
 
 ### Fixed

--- a/cognite/experimental/_api/alerts.py
+++ b/cognite/experimental/_api/alerts.py
@@ -17,8 +17,6 @@ from cognite.experimental.data_classes.alerts import (
     AlertSubscription,
     AlertSubscriptionDelete,
     AlertSubscriptionList,
-    DeduplicateAlert,
-    DeduplicateAlertList,
 )
 
 
@@ -202,7 +200,7 @@ class AlertsAPI(APIClient):
 
     def create_deduplicated(
         self,
-        alerts: Union[DeduplicateAlert, List[DeduplicateAlert]],
+        alerts: Union[Alert, List[Alert]],
     ) -> Union[Alert, AlertList]:
         assert_type(alerts, "alerts", [Alert, list])
         return self._create_multiple(

--- a/cognite/experimental/data_classes/alerts.py
+++ b/cognite/experimental/data_classes/alerts.py
@@ -143,57 +143,6 @@ class Alert(CogniteResource):
         self.triggered_points = triggered_points
         self._cognite_client = cast("CogniteClient", cognite_client)
 
-
-class DeduplicateAlert(CogniteResource):
-    """Alert"""
-
-    def __init__(
-        self,
-        id: int = None,
-        external_id: str = None,
-        timestamp: int = None,
-        channel_id: int = None,
-        channel_external_id: str = None,
-        source: str = None,
-        value: str = None,
-        level: str = None,
-        metadata: Dict[str, str] = None,
-        acknowledged: bool = None,
-        closed: bool = None,
-        triggered_points: List[Dict[str, str]] = None,
-        cognite_client: "CogniteClient" = None,
-        status: str = None,
-        start_time: int = None,
-        last_triggered_time: int = None,
-        created_time: int = None,
-        last_updated_time: int = None,
-    ):
-        self.id = id
-        self.external_id = external_id
-        self.timestamp = timestamp
-        self.channel_id = channel_id
-        self.channel_external_id = channel_external_id
-        self.source = source
-        self.value = value
-        self.level = level
-        self.metadata = metadata
-        self.acknowledged = acknowledged
-        self.closed = closed
-        self.triggered_points = triggered_points
-        self._cognite_client = cast("CogniteClient", cognite_client)
-        self.status = status
-        self.last_triggered_time = last_triggered_time
-        self.created_time = created_time
-        self.last_updated_time = last_updated_time
-        self.start_time = start_time
-
-
-class DeduplicateAlertList(CogniteResourceList):
-    _RESOURCE = DeduplicateAlert
-    _UPDATE = None
-    _ASSERT_CLASSES = False
-
-
 class AlertList(CogniteResourceList):
     _RESOURCE = Alert
     _UPDATE = None

--- a/cognite/experimental/data_classes/alerts.py
+++ b/cognite/experimental/data_classes/alerts.py
@@ -143,6 +143,7 @@ class Alert(CogniteResource):
         self.triggered_points = triggered_points
         self._cognite_client = cast("CogniteClient", cognite_client)
 
+
 class AlertList(CogniteResourceList):
     _RESOURCE = Alert
     _UPDATE = None

--- a/cognite/experimental/data_classes/alerts.py
+++ b/cognite/experimental/data_classes/alerts.py
@@ -110,6 +110,14 @@ class AlertChannelFilter(CogniteFilter):
         self._cognite_client = cast("CogniteClient", cognite_client)
 
 
+class AlertTriggeredPoint:
+    """Triggered point, will be deduplicated into one or more alerts"""
+
+    def __init__(self, triggered: int, timestamp: int):
+        self.timestamp = timestamp
+        self.triggered = triggered
+
+
 class Alert(CogniteResource):
     """Alert"""
 
@@ -126,7 +134,7 @@ class Alert(CogniteResource):
         metadata: Dict[str, str] = None,
         acknowledged: bool = None,
         closed: bool = None,
-        triggered_points: List[Dict[str, str]] = None,
+        triggered_points: Optional[List[AlertTriggeredPoint]] = None,
         cognite_client: "CogniteClient" = None,
     ):
         self.id = id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.108.1"
+version = "0.108.2"
 
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]

--- a/tests/tests_integration/test_alerts/test_alerts.py
+++ b/tests/tests_integration/test_alerts/test_alerts.py
@@ -16,8 +16,6 @@ from cognite.experimental.data_classes.alerts import (
     AlertSubscriber,
     AlertSubscription,
     AlertSubscriptionDelete,
-    DeduplicateAlert,
-    DeduplicateAlertList,
 )
 
 CURRENT_TS = datetime.now(timezone.utc)


### PR DESCRIPTION
## Checklist
Removed unused models in the alerts api.
Deduplicate alert method is not usable, and doesn't accept correct models (throws error due to `assert_type(alerts, "alerts", [Alert, list])`).


- [ x] Changelog entry added in `CHANGELOG` or not relevant for this change
- [ x] Version updated in `pyproject.toml` or not relevant for this change
