### PR TITLE
Mark alerts/deduplicate as retryable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.110.1]
+
+### Changed
+- /alerts/deduplicate (`alert.create_deduplicated(...)`) is now retryable
+
 ## [0.110.0]
 
 ### Changed

--- a/cognite/experimental/_client.py
+++ b/cognite/experimental/_client.py
@@ -19,7 +19,11 @@ from cognite.experimental._api.pnid_parsing import PNIDParsingAPI
 from cognite.experimental._api.templatecompletion import ExperimentalTemplatesAPI
 
 APIClient._RETRYABLE_POST_ENDPOINT_REGEX_PATTERNS |= {
-    "^" + path + "(\?.*)?$" for path in ("/(types|labels|templates)/(list|byids|search)",)
+    "^" + path + "(\?.*)?$"
+    for path in (
+        "/(types|labels|templates)/(list|byids|search)",
+        "/alerts/deduplicate",
+    )
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.110.0"
+version = "0.110.1"
 
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]


### PR DESCRIPTION
Registed alerts/deduplicate (`client.alerts.create_deduplicated(...)`) as retryable

## Checklist

- [x] Changelog entry added in `CHANGELOG` or not relevant for this change
- [x] Version updated in `pyproject.toml` or not relevant for this change
