### PR TITLE
lock cognite-sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.112.0]
+
+### Changed
+- Increase cognite-sdk major version (5 -> 6)
+
+### Fixed
+- Lock cognite-sdk version
+
 ## [0.111.0]
 
 ### Removed

--- a/cognite/experimental/_api/annotations.py
+++ b/cognite/experimental/_api/annotations.py
@@ -1,10 +1,11 @@
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Union
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes._base import CogniteResource
-from cognite.client.utils._auxiliary import assert_type, to_camel_case, to_snake_case
-from cognite.client.utils._identifier import Identifier, IdentifierSequence
+from cognite.client.utils._auxiliary import assert_type
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._text import to_camel_case
 
 from cognite.experimental.data_classes import Annotation, AnnotationFilter, AnnotationList, AnnotationUpdate
 

--- a/cognite/experimental/_api/legacy_annotations.py
+++ b/cognite/experimental/_api/legacy_annotations.py
@@ -1,8 +1,9 @@
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Union
 
 from cognite.client._api_client import APIClient
-from cognite.client.utils._auxiliary import assert_type, to_camel_case, to_snake_case
-from cognite.client.utils._identifier import Identifier, IdentifierSequence
+from cognite.client.utils._auxiliary import assert_type
+from cognite.client.utils._identifier import IdentifierSequence
+from cognite.client.utils._text import to_camel_case
 
 from cognite.experimental.data_classes import (
     LegacyAnnotation,

--- a/cognite/experimental/_api/match_rules.py
+++ b/cognite/experimental/_api/match_rules.py
@@ -1,6 +1,6 @@
-from typing import Dict, List, Union
+from typing import List, Union
 
-from cognite.client import utils
+from cognite.client.utils._text import to_camel_case
 
 from cognite.experimental._context_client import ContextAPI
 from cognite.experimental.data_classes import EntityMatchingMatchRuleList, MatchRulesApplyJob, MatchRulesSuggestJob
@@ -49,7 +49,7 @@ class MatchRulesAPI(ContextAPI):
             MatchRulesSuggestJob: Resulting queued job. Note that .rules property of this job will block waiting for
             results.
         """
-        matches = [{utils._auxiliary.to_camel_case(k): v for k, v in match.items()} for match in matches]
+        matches = [{to_camel_case(k): v for k, v in match.items()} for match in matches]
         return self._run_job(
             job_path="/suggest",
             status_path="/suggest/",

--- a/cognite/experimental/_context_client.py
+++ b/cognite/experimental/_context_client.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Union
 
 from cognite.client._api_client import APIClient
 from cognite.client.data_classes import ContextualizationJob
-from cognite.client.utils._auxiliary import to_camel_case
+from cognite.client.utils._text import to_camel_case
 from requests import Response
 
 

--- a/cognite/experimental/_context_client.py
+++ b/cognite/experimental/_context_client.py
@@ -61,8 +61,10 @@ class ContextAPI(APIClient):
         job_cls = job_cls or ContextualizationJob
         if status_path is None:
             status_path = job_path + "/"
+        response = self._camel_post(job_path, json=kwargs, headers=headers)
         return job_cls._load_with_status(
-            self._camel_post(job_path, json=kwargs, headers=headers).json(),
+            data=response.json(),
+            headers=response.headers,
             status_path=self._RESOURCE_PATH + status_path,
             cognite_client=self._cognite_client,
         )

--- a/cognite/experimental/data_classes/annotations.py
+++ b/cognite/experimental/data_classes/annotations.py
@@ -9,7 +9,7 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     CogniteUpdate,
 )
-from cognite.client.utils._auxiliary import to_snake_case
+from cognite.client.utils._text import to_snake_case
 
 
 class Annotation(CogniteResource):

--- a/cognite/experimental/data_classes/contextualization.py
+++ b/cognite/experimental/data_classes/contextualization.py
@@ -11,7 +11,7 @@ from cognite.client.data_classes._base import (
     CogniteResourceList,
     CogniteUpdate,
 )
-from cognite.client.utils._auxiliary import to_camel_case
+from cognite.client.utils._text import to_camel_case
 
 from cognite.experimental.data_classes.utils.pandas import dataframe_summarize
 from cognite.experimental.data_classes.utils.rules_output import _color_matches, _label_groups

--- a/cognite/experimental/data_classes/geospatial.py
+++ b/cognite/experimental/data_classes/geospatial.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Union, cast
 
 from cognite.client import utils
 from cognite.client.data_classes._base import CogniteResource, CogniteResourceList
-from cognite.client.utils._auxiliary import to_snake_case
+from cognite.client.utils._text import to_snake_case
 
 
 class FeatureType(CogniteResource):

--- a/cognite/experimental/utils.py
+++ b/cognite/experimental/utils.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from cognite.client.utils._auxiliary import to_camel_case, to_snake_case
+from cognite.client.utils._text import to_camel_case, to_snake_case
 
 
 def use_v1_instead_of_playground(f):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2074,4 +2074,4 @@ geopandas = ["geopandas", "shapely"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0.0"
-content-hash = "a85bd415c03cf264d9376db4412b5b7fa84cc88e041b1b46dd9a8e282532303b"
+content-hash = "bb1b9489ddf69f53765155aa3c0e111299ba28ee44b2bd697838f52999618545"

--- a/poetry.lock
+++ b/poetry.lock
@@ -328,29 +328,32 @@ test = ["pytest-cov"]
 
 [[package]]
 name = "cognite-sdk"
-version = "5.3.4"
+version = "6.0.2"
 description = "Cognite Python SDK"
 category = "main"
 optional = false
 python-versions = ">=3.8,<4.0"
 files = [
-    {file = "cognite_sdk-5.3.4-py3-none-any.whl", hash = "sha256:dbb710957d791e17d073e77d411a813c60d7144227b62b0597b8ce8b23ef6628"},
-    {file = "cognite_sdk-5.3.4.tar.gz", hash = "sha256:0f14f3ac2cc1c30bef77c2ad237795b47a2b8f8191e7923e7430759ee23f9729"},
+    {file = "cognite_sdk-6.0.2-py3-none-any.whl", hash = "sha256:7521b7575825dfe7c3d10f93e9b1bd139ad53a9409ba91d48ad79d1284bd1b54"},
+    {file = "cognite_sdk-6.0.2.tar.gz", hash = "sha256:57f3ea83e80840d4315ab3457fa3f80fd0cb412ebce66ed4b22ccbe9521002ec"},
 ]
 
 [package.dependencies]
+graphlib-backport = {version = ">=1.0.0,<2.0.0", markers = "python_version < \"3.9\""}
 msal = ">=1,<2"
 protobuf = ">=3.16.0"
 requests = ">=2,<3"
 requests_oauthlib = ">=1,<2"
 sortedcontainers = ">=2.2,<3.0"
+tzdata = {version = ">=2023.3", markers = "sys_platform == \"win32\""}
 
 [package.extras]
-all = ["geopandas (>=0.10.0)", "pandas (>=1.4,<2.0)", "pip (>=20.0.0)", "shapely (>=1.7.0)", "sympy"]
+all = ["backports-zoneinfo[tzdata] (>=0.2.1)", "geopandas (>=0.10.0)", "pandas (>=1.4)", "pip (>=20.0.0)", "shapely (>=1.7.0)", "sympy"]
 functions = ["pip (>=20.0.0)"]
 geo = ["geopandas (>=0.10.0)", "shapely (>=1.7.0)"]
 numpy = ["numpy (>=1.20,<2.0)"]
-pandas = ["pandas (>=1.4,<2.0)"]
+pandas = ["backports-zoneinfo[tzdata] (>=0.2.1)", "pandas (>=1.4)"]
+pyodide = ["pyodide-http (>=0.2.0,<0.3.0)"]
 sympy = ["sympy"]
 
 [[package]]
@@ -579,6 +582,18 @@ packaging = "*"
 pandas = ">=1.0.0"
 pyproj = ">=2.6.1.post1"
 shapely = ">=1.7"
+
+[[package]]
+name = "graphlib-backport"
+version = "1.0.3"
+description = "Backport of the Python 3.9 graphlib module for Python 3.6+"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+files = [
+    {file = "graphlib_backport-1.0.3-py3-none-any.whl", hash = "sha256:24246967b9e7e6a91550bc770e6169585d35aa32790258579a8a3899a8c18fde"},
+    {file = "graphlib_backport-1.0.3.tar.gz", hash = "sha256:7bb8fc7757b8ae4e6d8000a26cd49e9232aaa9a3aa57edb478474b8424bfaae2"},
+]
 
 [[package]]
 name = "identify"
@@ -1976,6 +1991,18 @@ files = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2023.3"
+description = "Provider of IANA time zone data"
+category = "main"
+optional = false
+python-versions = ">=2"
+files = [
+    {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
+    {file = "tzdata-2023.3.tar.gz", hash = "sha256:11ef1e08e54acb0d4f95bdb1be05da659673de4acbd21bf9c69e94cc5e907a3a"},
+]
+
+[[package]]
 name = "urllib3"
 version = "1.26.14"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -2047,4 +2074,4 @@ geopandas = ["geopandas", "shapely"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0.0"
-content-hash = "2b46455befc177569fd90fcd8e7f6176333c061d72661d200b5d1620e9016ce1"
+content-hash = "a85bd415c03cf264d9376db4412b5b7fa84cc88e041b1b46dd9a8e282532303b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.111.0"
+version = "0.112.0"
 
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ commands =
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0.0"
-cognite-sdk = "^5"
+cognite-sdk = "6.0.2"
 responses = "^0.13.3"
 sympy = "^1.3.0"
 typing-extensions = ">=3.7.4,<5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ commands =
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0.0"
-cognite-sdk = "6.0.2"
+cognite-sdk = "~6.0.2"
 responses = "^0.13.3"
 sympy = "^1.3.0"
 typing-extensions = ">=3.7.4,<5"

--- a/tests/tests_unit/test_contextualization/test_entity_matching.py
+++ b/tests/tests_unit/test_contextualization/test_entity_matching.py
@@ -73,7 +73,7 @@ class TestEntityMatching:
         assert isinstance(job, ContextualizationJob)
         assert "Queued" == job.status
         assert 456 == job.job_id
-        assert "ContextualizationJob(id: 456,status: Queued,error: None)" == str(job)
+        assert "ContextualizationJob(id=456, status=Queued, error=None)" == str(job)
         assert {"items": [1]} == job.result
         assert "Completed" == job.status
 
@@ -94,7 +94,7 @@ class TestEntityMatching:
             feature_type="bigram",
             replacements=[{"field": "*", "from": "BADUK", "to": "GO"}],
         )
-        assert "EntityMatchingModel(id: 123,status: Queued,error: None)" == str(model)
+        assert "EntityMatchingModel(id=123, status=Queued, error=None)" == str(model)
         assert 42 == model.created_time
         model.wait_for_completion()
         assert "Completed" == model.status

--- a/tests/tests_unit/test_data_classes/test_annotations.py
+++ b/tests/tests_unit/test_data_classes/test_annotations.py
@@ -2,7 +2,7 @@ import json
 from typing import Optional
 
 import pytest
-from cognite.client.utils._auxiliary import to_snake_case
+from cognite.client.utils._text import to_snake_case
 
 from cognite.experimental.data_classes import Annotation, AnnotationFilter, AnnotationUpdate, annotations
 


### PR DESCRIPTION
Update and lock cognite-python-sdk version. Since this package depends on internal functions, e.g., stuff in  `cognite.client.utils._auxiliary`, it should be strictly locked. Have observed pulling this library, with a newer version of cognite-sdk than specified in the poetry.lock (but still allowed by pyproject) and getting errors because of moving / removal of these internal functions. 

Note, we should really start using a stricter linting/type-checking setup, I see a ton of unused imports, typing mismatches in my IDE. Maybe go with ruff and pyright @cognitedata/matchmakers ?

## Checklist

- [x] Changelog entry added in `CHANGELOG` or not relevant for this change
- [x] Version updated in `pyproject.toml` or not relevant for this change
