### PR TITLE
Lock cognite-sdk version to major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.113.1]
+
+### Fixed
+- Lock cognite-sdk version to major only
+
 ## [0.113.0]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "cognite-sdk-experimental"
 
-version = "0.113.0"
+version = "0.113.1"
 
 description = "Experimental additions to the Python SDK"
 authors = ["Sander Land <sander.land@cognite.com>"]
@@ -44,7 +44,7 @@ commands =
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4.0.0"
-cognite-sdk = "~6.0.2"
+cognite-sdk = "^6.0.2"
 responses = "^0.13.3"
 sympy = "^1.3.0"
 typing-extensions = ">=3.7.4,<5"


### PR DESCRIPTION
## Checklist
need to relax the constraint as people cannot run this on newer versions of cognite-sdk

- [x ] Changelog entry added in `CHANGELOG` or not relevant for this change
- [ x] Version updated in `pyproject.toml` or not relevant for this change
